### PR TITLE
rename 5.5a -> 5.5b

### DIFF
--- a/2011/12/7-055b-is-out/index.html
+++ b/2011/12/7-055b-is-out/index.html
@@ -125,7 +125,7 @@
     </div>
     <div style="width: 500px">
       
-<h2 class="post">0.5.5a is out!</h2>
+<h2 class="post">0.5.5b is out!</h2>
 <div class="information">
    <span class="date">2011-12-05</span>
 </div>


### PR DESCRIPTION
It looks like you forgot to update the 5.5a page to refer to 5.5b.
The slic3r home page links to http://slic3r.org/2011/12/7-055b-is-out which doesn't exist.
I think this is probably what you wanted?
Just trying to help :)
