### PR TITLE
Made the UI look quite a bit nicer (OS X 10.7 tested).

### DIFF
--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -9,12 +9,12 @@ our $Options = {
 
     # miscellaneous options
     'notes' => {
-        label   => 'Configuraton notes',
+        label   => 'Configuration notes',
         cli		=> 'notes=s',
         type    => 's',
         multiline => 1,
-        width   => 350,
-        height  => 300,
+        width   => 213,
+        height  => 150,
         serialize   => sub { join '\n', split /\R/, $_[0] },
         deserialize => sub { join "\n", split /\\n/, $_[0] },
     },
@@ -73,7 +73,7 @@ our $Options = {
         type    => 'bool',
     },
     'gcode_comments' => {
-        label   => 'Verbose GCODE (comments)',
+        label   => 'GCODE comments',
         cli     => 'gcode-comments',
         type    => 'bool',
     },

--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -30,11 +30,17 @@ sub OnInit {
     
     # File menu
     my $fileMenu = Wx::Menu->new;
-    $fileMenu->Append(1, "Slice...");
-    $fileMenu->Append(2, "Slice and save as...");
+    $fileMenu->Append(1, "Save Config…");
+    $fileMenu->Append(2, "Open Config…");
+    $fileMenu->AppendSeparator();
+    $fileMenu->Append(3, "Slice…");
+    $fileMenu->Append(4, "Slice and Save As…");
     $menubar->Append($fileMenu, "&File");
-    EVT_MENU($frame, 1, sub { $panel->do_slice });
-    EVT_MENU($frame, 2, sub { $panel->do_slice(save_as => 1) });
+    EVT_MENU($frame, 1, sub { $panel->save_config });
+    EVT_MENU($frame, 2, sub { $panel->load_config });
+    EVT_MENU($frame, 3, sub { $panel->do_slice });
+    EVT_MENU($frame, 4, sub { $panel->do_slice(save_as => 1) });
+    
     
     $box->SetSizeHints($frame);
     $frame->SetSizer($box);

--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -111,42 +111,65 @@ sub new {
         $make_tab->([qw(cooling)]),
         $make_tab->([qw(printer filament)], [qw(print_speed speed)]),
         $make_tab->([qw(gcode)]),
-        $make_tab->([qw(notes)]),
-        $make_tab->([qw(extrusion)], [qw(output)]),
+        $make_tab->([qw(notes)], [qw(extrusion output)]),
     );
     
-    $tabpanel->AddPage($tabs[0], "Print Settings");
+    $tabpanel->AddPage($tabs[0], "Printing");
     $tabpanel->AddPage($tabs[1], "Cooling");
-    $tabpanel->AddPage($tabs[2], "Printer and Filament");
-    $tabpanel->AddPage($tabs[3], "Start/End GCODE");
-    $tabpanel->AddPage($tabs[4], "Notes");
-    $tabpanel->AddPage($tabs[5], "Advanced");
+    $tabpanel->AddPage($tabs[2], "Extruding");
+    $tabpanel->AddPage($tabs[3], "GCODE");
+    $tabpanel->AddPage($tabs[4], "Advanced");
         
     my $buttons_sizer;
     {
         $buttons_sizer = Wx::BoxSizer->new(wxHORIZONTAL);
         
-        my $slice_button = Wx::Button->new($self, -1, "Slice...");
-        $slice_button->SetDefault();
-        $buttons_sizer->Add($slice_button, 0);
-        EVT_BUTTON($self, $slice_button, sub { $self->do_slice });
         
-        my $save_button = Wx::Button->new($self, -1, "Save configuration...");
-        $buttons_sizer->Add($save_button, 0);
+        my $buttons_left_sizer = Wx::BoxSizer->new(wxHORIZONTAL);
+        $buttons_left_sizer->SetMinSize(300, 0);
+        
+        my $save_button = Wx::Button->new($self, -1, "Save Config…");
+        $buttons_left_sizer->Add($save_button, 0);
         EVT_BUTTON($self, $save_button, sub { $self->save_config });
         
-        my $load_button = Wx::Button->new($self, -1, "Load configuration...");
-        $buttons_sizer->Add($load_button, 0);
+        $buttons_left_sizer->Add((14, 0), 0);
+        
+        my $load_button = Wx::Button->new($self, -1, "Open Config…");
+        $buttons_left_sizer->Add($load_button, 0);
         EVT_BUTTON($self, $load_button, sub { $self->load_config });
         
-        my $text = Wx::StaticText->new($self, -1, "Remember to check for updates at http://slic3r.org/\nVersion: $Slic3r::VERSION", Wx::wxDefaultPosition, Wx::wxDefaultSize, wxALIGN_RIGHT);
+        $buttons_sizer->Add($buttons_left_sizer, 1);
+        
+        
         my $font = Wx::Font->new(10, wxDEFAULT, wxNORMAL, wxNORMAL);
+        my $update_sizer = Wx::BoxSizer->new(wxVERTICAL);
+        
+        my $text = Wx::StaticText->new($self, -1, "Version $Slic3r::VERSION");
         $text->SetFont($font);
-        $buttons_sizer->Add($text, 1, wxEXPAND | wxALIGN_RIGHT);
+        $update_sizer->Add($text, 0, wxALIGN_CENTRE);
+        
+        my $link = Wx::HyperlinkCtrl->new($self, -1, "Check for updates", "http://slic3r.org/");
+        $link->SetFont($font);
+        $update_sizer->Add($link, 0, wxALIGN_CENTRE);
+        
+        $buttons_sizer->Add($update_sizer, 0, wxEXPAND);
+        
+        
+        my $buttons_right_sizer = Wx::BoxSizer->new(wxHORIZONTAL);
+        $buttons_right_sizer->SetMinSize(300, 0);
+        
+        $buttons_right_sizer->AddStretchSpacer();
+        
+        my $slice_button = Wx::Button->new($self, -1, "Slice…");
+        $slice_button->SetDefault();
+        $buttons_right_sizer->Add($slice_button, 0, wxALIGN_RIGHT);
+        EVT_BUTTON($self, $slice_button, sub { $self->do_slice });
+        
+        $buttons_sizer->Add($buttons_right_sizer, 1, wxALIGN_RIGHT);
     }
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);
-    $sizer->Add($buttons_sizer, 0, wxEXPAND | wxALL, 10);
+    $sizer->Add($buttons_sizer, 0, wxEXPAND | wxALL, (14));
     $sizer->Add($tabpanel);
     
     $sizer->SetSizeHints($self);


### PR DESCRIPTION
- Added link to website for updates
- Moved 'Slice…' button to the right as this more logically follows the
  user's flow through the application
- Moved version information to the middle right under the App name (on
  OS X anyway) as it is clearer what the version is referring to
- Added spacing between the buttons
- Removed colon after 'version' as this is the UI convention in about
  boxes
- Changed 'Load' to 'Open' as this is the more commonly used term
- Truncated 'Configuration' to 'Config' to save space, and I believe it
  is still clear what it means
- Added open and save config to File menu as this is more conventional
  location
- Simplified some wording
- Rephrased the tabs to be more succinct, I believe they still make
  sense
- Fixed a spelling
- Replaced '…' with proper ellipses character
