### PR TITLE
Use correct spelling for G-code

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,7 +36,7 @@ Slic3r current key features are:
 * center print around bed center point;
 * multiple solid layers near horizontal external surfaces;
 * ability to scale, rotate and duplicate input object;
-* customizable initial and final GCODE;
+* customizable initial and final G-code;
 * support material;
 * cooling and fan control;
 * use different speed for bottom layer and perimeters.
@@ -108,7 +108,7 @@ The author is Alessandro Ranellucci (me).
                             by all firmwares)
         --g0                Use G0 commands for retraction (experimental, not supported by all
                             firmwares)
-        --gcode-comments    Make GCODE verbose by adding comments (default: no)
+        --gcode-comments    Make G-code verbose by adding comments (default: no)
         
       Filament options:
         --filament-diameter Diameter in mm of your raw filament (default: 3)

--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -63,7 +63,7 @@ our $Options = {
         type    => 'f',
     },
     'gcode_arcs' => {
-        label   => 'Use native GCODE arcs',
+        label   => 'Use native G-code arcs',
         cli     => 'gcode-arcs',
         type    => 'bool',
     },
@@ -250,7 +250,7 @@ our $Options = {
         labels  => [qw(Primary Secondary)],
     },
     'start_gcode' => {
-        label   => 'Start GCODE',
+        label   => 'Start G-code',
         cli     => 'start-gcode=s',
         type    => 's',
         multiline => 1,
@@ -260,7 +260,7 @@ our $Options = {
         deserialize => sub { join "\n", split /\\n/, $_[0] },
     },
     'end_gcode' => {
-        label   => 'End GCODE',
+        label   => 'End G-code',
         cli     => 'end-gcode=s',
         type    => 's',
         multiline => 1,
@@ -270,7 +270,7 @@ our $Options = {
         deserialize => sub { join "\n", split /\\n/, $_[0] },
     },
     'layer_gcode' => {
-        label   => 'Layer Change GCODE',
+        label   => 'Layer Change G-code',
         cli     => 'layer-gcode=s',
         type    => 's',
         multiline => 1,

--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -63,7 +63,7 @@ sub new {
             options => [qw(scale rotate duplicate_x duplicate_y duplicate_distance)],
         },
         gcode => {
-            title => 'Custom GCODE',
+            title => 'Custom G-code',
             options => [qw(start_gcode end_gcode layer_gcode gcode_comments post_process)],
         },
         extrusion => {
@@ -120,7 +120,7 @@ sub new {
     $tabpanel->AddPage($tabs[0], "Print Settings");
     $tabpanel->AddPage($tabs[1], "Cooling");
     $tabpanel->AddPage($tabs[2], "Printer and Filament");
-    $tabpanel->AddPage($tabs[3], "Start/End GCODE");
+    $tabpanel->AddPage($tabs[3], "Custom G-code");
     $tabpanel->AddPage($tabs[4], "Notes");
     $tabpanel->AddPage($tabs[5], "Advanced");
         
@@ -160,7 +160,7 @@ sub new {
 
 my $model_wildcard = "STL files (*.stl)|*.stl;*.STL|AMF files (*.amf)|*.amf;*.AMF;*.xml;*.XML";
 my $ini_wildcard = "INI files *.ini|*.ini;*.INI";
-my $gcode_wildcard = "GCODE files *.gcode|*.gcode;*.GCODE";
+my $gcode_wildcard = "G-code files *.gcode|*.gcode;*.GCODE";
 
 sub do_slice {
     my $self = shift;

--- a/lib/Slic3r/Skein.pm
+++ b/lib/Slic3r/Skein.pm
@@ -133,9 +133,9 @@ sub go {
     $self->status_cb->(88, "Generating skirt");
     $print->extrude_skirt;
     
-    # output everything to a GCODE file
+    # output everything to a G-code file
     my $output_file = $self->expanded_output_filepath;
-    $self->status_cb->(90, "Exporting GCODE to $output_file");
+    $self->status_cb->(90, "Exporting G-code to $output_file");
     $print->export_gcode($output_file);
     
     # run post-processing scripts

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -131,7 +131,7 @@ Usage: slic3r.pl [ OPTIONS ] file.stl
                         by all firmwares)
     --g0                Use G0 commands for retraction (experimental, not supported by all
                         firmwares)
-    --gcode-comments    Make GCODE verbose by adding comments (default: no)
+    --gcode-comments    Make G-code verbose by adding comments (default: no)
     
   Filament options:
     --filament-diameter Diameter in mm of your raw filament (default: $Slic3r::filament_diameter)


### PR DESCRIPTION
According to http://en.wikipedia.org/wiki/G-code and http://reprap.org/wiki/G-code, the correct spelling is "G-code", not "GCODE". Currently, Slic3r uses a mix of both.

This commit changes all occurrences (except for "STL-to-GCODE" uses) to "G-code" for consistency.
