### PR TITLE
Fix leaking FileDialog by issuing Destroy to it after it has been used

### DIFF
--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -189,8 +189,12 @@ sub do_slice {
         my $input_file;
         if (!$params{reslice}) {
             my $dialog = Wx::FileDialog->new($self, 'Choose a STL or AMF file to slice:', $dir, "", $model_wildcard, wxFD_OPEN);
-            return unless $dialog->ShowModal == wxID_OK;
+            if ($dialog->ShowModal != wxID_OK) {
+                $dialog->Destroy;
+                return;
+            }
             $input_file = $dialog->GetPaths;
+            $dialog->Destroy;
             $last_input_file = $input_file;
         } else {
             if (!defined $last_input_file) {
@@ -229,9 +233,13 @@ sub do_slice {
             $output_file =~ s/\.gcode$/.svg/i if $params{export_svg};
             my $dlg = Wx::FileDialog->new($self, 'Save ' . ($params{export_svg} ? 'SVG' : 'G-code') . ' file as:', dirname($output_file),
                 basename($output_file), $gcode_wildcard, wxFD_SAVE);
-            return if $dlg->ShowModal != wxID_OK;
+            if ($dlg->ShowModal != wxID_OK) {
+                $dlg->Destroy;
+                return;
+            }
             $skein->output_file($dlg->GetPath);
             $last_output_file = $dlg->GetPath;
+            $dlg->Destroy;
         }
         
         # show processbar dialog
@@ -288,6 +296,7 @@ sub save_config {
         $last_config = $file;
         Slic3r::Config->save($file);
     }
+    $dlg->Destroy;
 }
 
 sub load_config {
@@ -307,6 +316,7 @@ sub load_config {
         $self->catch_error();
         $_->() for @Slic3r::GUI::OptionsGroup::reload_callbacks;
     }
+    $dlg->Destroy;
 }
 
 sub catch_error {


### PR DESCRIPTION
This also works around the bug in GTK in its file system tracking/file
open dialog that causes a crash when a file (in a directory it is tracking,
such as the previous directry where an STL was sliced from) is modified
with vim.

Steps to reproduce the bug:
1) Slice a file from the GUI
2) vim test.stl in the same directory
3) i hello ESC ZZ
4) if Slic3r didn't crash to a gtk assertion failure, jump to step 2
5) if still no luck, your gtk isn't broken. What version do you have?-)
