### PR TITLE
Add an env var to prevent the Build.PL from installing dependencies.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -27,7 +27,11 @@ my $build = Module::Build->new(
     },
     script_files    => ['slic3r.pl'],
 );
-$build->dispatch('installdeps');
-$build->dispatch('test', verbose => 0);
+
+if (not $ENV{SLIC3R_NO_AUTO})
+{
+    $build->dispatch('installdeps');
+    $build->dispatch('test', verbose => 0);
+}
 
 $build->create_build_script;


### PR DESCRIPTION
It's optional and defaults to off but people can set it if they would
like to install the dependencies in a different way.
