### PR TITLE
Zero solid layers error

### DIFF
--- a/lib/Slic3r/Fill.pm
+++ b/lib/Slic3r/Fill.pm
@@ -143,7 +143,9 @@ sub make_fill {
         
         # force 100% density and rectilinear fill for external surfaces
         if ($surface->surface_type != S_TYPE_INTERNAL) {
-            $density = 1;
+			if ($Slic3r::solid_layers != 0) {
+						$density = 1;
+			}
             $filler = $Slic3r::solid_fill_pattern;
             if ($is_bridge) {
                 $filler = 'rectilinear';

--- a/lib/Slic3r/Layer.pm
+++ b/lib/Slic3r/Layer.pm
@@ -340,11 +340,6 @@ sub prepare_fill_surfaces {
         @surfaces = (grep($_->surface_type != S_TYPE_TOP, @surfaces), @top);
     }
     
-    # remove top/bottom surfaces
-    if ($Slic3r::solid_layers == 0) {
-        @surfaces = grep $_->surface_type == S_TYPE_INTERNAL, @surfaces;
-    }
-    
     # remove internal surfaces
     if ($Slic3r::fill_density == 0) {
         @surfaces = grep $_->surface_type != S_TYPE_INTERNAL, @surfaces;


### PR DESCRIPTION
There was a small bug in the main branch.  With zero solid layers only the outline would be printed with no fill at all.  I don't think this is the correct way to do things, if nothing else no fill would be on the bottom so its unlikely the print would complete anyway. I've changed it (probably crudely, I've never done perl before :) ) so that it does coarse fill instead. 
