### PR TITLE
Moved start_gcode to actual start of gcode commands

### DIFF
--- a/lib/Slic3r/Print.pm
+++ b/lib/Slic3r/Print.pm
@@ -455,11 +455,11 @@ sub write_gcode {
     print $fh $extruder->set_fan(0, 1) if $Slic3r::cooling && $Slic3r::disable_fan_first_layers;
     
     # write start commands to file
+    printf $fh "%s\n", Slic3r::Config->replace_options($Slic3r::start_gcode); # allow for possible M80 in start_gcode to enable the PSU.
     printf $fh $extruder->set_bed_temperature($Slic3r::first_layer_bed_temperature, 1),
             if $Slic3r::first_layer_bed_temperature && $Slic3r::start_gcode !~ /M190/i;
     printf $fh $extruder->set_temperature($Slic3r::first_layer_temperature)
         if $Slic3r::first_layer_temperature;
-    printf $fh "%s\n", Slic3r::Config->replace_options($Slic3r::start_gcode);
     printf $fh $extruder->set_temperature($Slic3r::first_layer_temperature, 1)
             if $Slic3r::first_layer_temperature && $Slic3r::start_gcode !~ /M109/i;
     print  $fh "G90 ; use absolute coordinates\n";


### PR DESCRIPTION
This allows for the start_gcode field to be used to switch on the PSU. 

(current version has a bug that means that if you set a first layer bed temperature in the options, you never get a chance to switch on your PSU and your printer just sits there waiting for the bed to heat up without power.)
