### PR TITLE
Various fixes/additions to the About dialog handling

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -78,6 +78,8 @@ sub About {
     my $info = Wx::AboutDialogInfo->new;
     $info->SetName('Slic3r');
     $info->AddDeveloper('Alessandro Ranellucci');
+    $info->SetVersion($Slic3r::VERSION);
+    $info->SetDescription('STL-to-GCODE translator for RepRap printers');
     
     Wx::AboutBox($info);
 }


### PR DESCRIPTION
Due to what appears to be a bug, special menu items such as wxID_ABOUT are not handled correctly on Mac OS X if SetMenuBar() is called before the special items are appended to the menubar. This patch reshuffles the menubar code a bit to enable the about dialog to be displayed on Mac OS X.

Seeing that the about dialog is now accessible, add the last two cross-platform pieces of information to this dialog (version and description) to provide a more native look and feel.
