### PR TITLE
Fix Slic3r::Polygon's boost_linestring method to properly close the polygon

### DIFF
--- a/lib/Slic3r/Polygon.pm
+++ b/lib/Slic3r/Polygon.pm
@@ -16,6 +16,11 @@ sub lines {
     return @lines;
 }
 
+sub boost_linestring {
+    my $self = shift;
+    return Boost::Geometry::Utils::linestring([@$self, $self->[0]]);
+}
+
 sub is_counter_clockwise {
     my $self = shift;
     return Math::Clipper::is_counter_clockwise($self);


### PR DESCRIPTION
This prevented Slic3r from detecting some bridge supporting edges
(basically, if that edge was the last one in the contour).  This
addresses some of the bridge detection issues (#414, #358).
