### PR TITLE
Move Growl::GNTP handling to Slic3r::GUI

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -12,6 +12,8 @@ use Wx 0.9901 qw(:sizer :frame wxID_EXIT wxID_ABOUT);
 use Wx::Event qw(EVT_MENU);
 use base 'Wx::App';
 
+my $growler;
+
 sub OnInit {
     my $self = shift;
     
@@ -27,6 +29,14 @@ sub OnInit {
     my $box = Wx::BoxSizer->new(wxVERTICAL);
     $box->Add($panel, 0);
     
+    if (eval "use Growl::GNTP; 1") {
+        # register growl notifications
+        eval {
+            $growler = Growl::GNTP->new(AppName => 'Slic3r', AppIcon => "$Slic3r::var/Slic3r.png");
+            $growler->register([{Name => 'SKEIN_DONE', DisplayName => 'Slicing Done'}]);
+        };
+    }
+
     # menubar
     my $menubar = Wx::MenuBar->new;
     $frame->SetMenuBar($menubar);
@@ -95,6 +105,15 @@ sub warning_catcher {
         $message_dialog
             ? $message_dialog->(@params)
             : Wx::MessageDialog->new($self, @params)->ShowModal;
+    };
+}
+
+sub notify {
+    my ($message) = @_;
+
+    eval {
+        $growler->notify(Event => 'SKEIN_DONE', Title => 'Slicing Done!', Message => $message)
+            if $growler;
     };
 }
 

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -519,11 +519,7 @@ sub export_gcode2 {
             $print->processing_time - int($print->processing_time/60)*60
                 if $print->processing_time;
         $message .= ".";
-        eval {
-            # TODO: fix it as we don't have $self->{growler}
-            $self->{growler}->notify(Event => 'SKEIN_DONE', Title => 'Slicing Done!', Message => $message)
-                if ($self->{growler});
-        };
+        Slic3r::GUI::notify($message);
         $params{on_completed}->($message);
         $print->cleanup;
     };

--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -86,14 +86,6 @@ sub new {
         },
     );
     $self->{panels} = \%panels;
-
-    if (eval "use Growl::GNTP; 1") {
-        # register growl notifications
-        eval {
-            $self->{growler} = Growl::GNTP->new(AppName => 'Slic3r', AppIcon => "$Slic3r::var/Slic3r.png");
-            $self->{growler}->register([{Name => 'SKEIN_DONE', DisplayName => 'Slicing Done'}]);
-        };
-    }
     
     my $tabpanel = Wx::Notebook->new($self, -1, Wx::wxDefaultPosition, Wx::wxDefaultSize, &Wx::wxNB_TOP);
     my $make_tab = sub {
@@ -272,10 +264,7 @@ sub do_slice {
             $print->processing_time - int($print->processing_time/60)*60
                 if $print->processing_time;
         $message .= ".";
-        eval {
-            $self->{growler}->notify(Event => 'SKEIN_DONE', Title => 'Slicing Done!', Message => $message)
-                if ($self->{growler});
-        };
+        Slic3r::GUI::notify($message);
         Wx::MessageDialog->new($self, $message, 'Done!', 
             wxOK | wxICON_INFORMATION)->ShowModal;
     };


### PR DESCRIPTION
Move Growl::GNTP handling to Slic3r::GUI to allow notifications from both Slic3r::GUI::SkeinPanel and Slic3r::GUI::Plater.
