### PR TITLE
Fix the timeout on the libnotify stuff

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -354,7 +354,7 @@ sub notify {
             my $serv = $session->get_service('org.freedesktop.Notifications');
             my $notifier = $serv->get_object('/org/freedesktop/Notifications',
                                              'org.freedesktop.Notifications');
-            $notifier->Notify('Slic3r', 0, $self->{icon}, $title, $message, [], {}, 5);
+            $notifier->Notify('Slic3r', 0, $self->{icon}, $title, $message, [], {}, 1500);
         }
     };
 }


### PR DESCRIPTION
It's in milliseconds so this should be at least 1.5 seconds.  Longer may or may not be better but this at least gives a chance to see the icon and text.
