### PR TITLE
Increase scale factor for Clipper::offset

### DIFF
--- a/lib/Slic3r/Geometry/Clipper.pm
+++ b/lib/Slic3r/Geometry/Clipper.pm
@@ -14,12 +14,12 @@ our $clipper = Math::Clipper->new;
 
 sub safety_offset {
     my ($polygons, $factor) = @_;
-    return Math::Clipper::offset($polygons, $factor || (scale 1e-05), 100, JT_MITER, 2);
+    return Math::Clipper::offset($polygons, $factor || (scale 1e-05), 100000, JT_MITER, 2);
 }
 
 sub offset {
     my ($polygons, $distance, $scale, $joinType, $miterLimit) = @_;
-    $scale      ||= &Slic3r::SCALING_FACTOR * 1000000;
+    $scale      ||= 100000;
     $joinType   = JT_MITER if !defined $joinType;
     $miterLimit ||= 2;
     

--- a/lib/Slic3r/Layer/Region.pm
+++ b/lib/Slic3r/Layer/Region.pm
@@ -330,7 +330,7 @@ sub prepare_fill_surfaces {
             
             # offset inwards
             my @offsets = $surface->expolygon->offset_ex(-$distance);
-            @offsets = @{union_ex(Math::Clipper::offset([ map @$_, @offsets ], $distance, 100, JT_MITER))};
+            @offsets = @{union_ex(Math::Clipper::offset([ map @$_, @offsets ], $distance, 100000, JT_MITER))};
             map Slic3r::Surface->new(
                 expolygon => $_,
                 surface_type => $surface->surface_type,


### PR DESCRIPTION
A default scale of 1 was being calculated most of the time. That's too
low to avoid artifacts from offsetting concave curves. Setting scale to
a default of 100000 eliminates artifacts in the test cases in issues
#700, #702 and #703. There is a risk of large point proliferation with

this scale in combination with the JT_ROUND option, but in the four
places where that option is used, scale is already explicitly set to a
safer low value.

More details and pictures about this in closed/canceled pull request #705
