### PR TITLE
parallel_degrees_limit decreased, 3 to 0.1, #704

### DIFF
--- a/lib/Slic3r/Geometry.pm
+++ b/lib/Slic3r/Geometry.pm
@@ -36,7 +36,7 @@ use constant X2 => 2;
 use constant Y2 => 3;
 use constant MIN => 0;
 use constant MAX => 1;
-our $parallel_degrees_limit = abs(deg2rad(3));
+our $parallel_degrees_limit = abs(deg2rad(0.1));
 
 sub epsilon () { 1E-4 }
 sub scaled_epsilon () { epsilon / &Slic3r::SCALING_FACTOR }


### PR DESCRIPTION
Using 0.1 degrees difference as the threshold for determining whether two adjacent segments are parallel is arbitrary, but gives better results for gradual curves than 3 degrees. With three degrees, gradual and/or high-res curves made of short segments are going to collapse into one segment that can deviate from the real perimeter by more than an extrusion width. 

SIDE EFFECT: Experimental arc detection currently uses
$parallel_degrees_limit in a couple ways. Setting it lower will make arc
detection more strict. Either that's a good thing, or the arc fitting
threshold and the parallel line test threshold need to be separate.

The hook model test case didn't reveal this problem until offset artifacts were resolved by the commit in pull request #720.
