### PR TITLE
use remove_coinciding_points before convex_hull

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -999,7 +999,7 @@ package Slic3r::GUI::Plater::Object;
 use Moo;
 
 use Math::ConvexHull qw(convex_hull);
-use Slic3r::Geometry qw(X Y);
+use Slic3r::Geometry qw(X Y remove_coinciding_points);
 
 has 'name'                  => (is => 'rw', required => 1);
 has 'input_file'            => (is => 'rw', required => 1);
@@ -1034,6 +1034,7 @@ sub make_thumbnail {
     my %params = @_;
     
     my @points = map [ @$_[X,Y] ], @{$self->mesh->vertices};
+    remove_coinciding_points(\@points);
     my $convex_hull = Slic3r::Polygon->new(convex_hull(\@points));
     for (@$convex_hull) {
         @$_ = map $_ * $params{scaling_factor}, @$_;

--- a/lib/Slic3r/Print.pm
+++ b/lib/Slic3r/Print.pm
@@ -6,7 +6,7 @@ use File::Spec;
 use List::Util qw(max);
 use Math::ConvexHull 1.0.4 qw(convex_hull);
 use Slic3r::ExtrusionPath ':roles';
-use Slic3r::Geometry qw(X Y Z X1 Y1 X2 Y2 MIN PI scale unscale move_points nearest_point);
+use Slic3r::Geometry qw(X Y Z X1 Y1 X2 Y2 MIN PI scale unscale move_points nearest_point remove_coinciding_points);
 use Slic3r::Geometry::Clipper qw(diff_ex union_ex intersection_ex offset JT_ROUND JT_SQUARE);
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -139,6 +139,7 @@ sub validate {
                 my $clearance;
                 {
                     my @points = map [ @$_[X,Y] ], map @{$_->vertices}, @{$self->objects->[$obj_idx]->meshes};
+                    remove_coinciding_points(\@points);
                     my $convex_hull = Slic3r::Polygon->new(convex_hull(\@points));
                     $clearance = +($convex_hull->offset(scale $Slic3r::Config->extruder_clearance_radius / 2, 1, JT_ROUND))[0];
                 }
@@ -552,6 +553,7 @@ sub make_skirt {
     return if @points < 3;  # at least three points required for a convex hull
     
     # find out convex hull
+    remove_coinciding_points(\@points);
     my $convex_hull = convex_hull(\@points);
     
     # draw outlines from outside to inside


### PR DESCRIPTION
Math::ConvexHull can give invalid results if it's input has duplicate points, and it only
screens for sequential duplicates. Non-sequential
duplicates resulting from flattening multiple z-level slices sometimes lead to erroneous, non-convex polygon output. 

STL: http://dl.dropbox.com/u/315849/Slic3r/z-motor-mount.stl

before and after fix:

![non-convex hull on the plater, and fix](https://a248.e.akamai.net/camo.github.com/de2d26c6b212c45dc995529200b4021c0fcf7df7/687474703a2f2f7368656c6472616b652e6e65742f6261672f636f6e7665785f68756c6c5f6669782e706e67)

Affects plater display, validate, and skirt.
