### PR TITLE
replace zero-sum offsets with union_ex()

### DIFF
--- a/lib/Slic3r/Layer/Region.pm
+++ b/lib/Slic3r/Layer/Region.pm
@@ -68,9 +68,8 @@ sub make_surfaces {
     
     return if !@$loops;    
     {
-        my $safety_offset = scale 0.1;
         # merge everything
-        my $expolygons = [ map $_->offset_ex(-$safety_offset), @{union_ex(safety_offset($loops, $safety_offset))} ];
+        my $expolygons = union_ex($loops);
         
         Slic3r::debugf "  %d surface(s) having %d holes detected from %d polylines\n",
             scalar(@$expolygons), scalar(map $_->holes, @$expolygons), scalar(@$loops);


### PR DESCRIPTION
The negative offset exposes a Clipper quirk that rarely reverses
winding order, which clobbers holes. 

After applying commit in #720 (increase scale factor for offset), this model, with this config, will lose holes on the first layer.

http://dl.dropbox.com/u/315849/Slic3r/z-motor-mount.stl
http://dl.dropbox.com/u/315849/Slic3r/layerfill/config-filltest.ini

(#720 doesn't cause this, it just happens to help set up the conditions that cause this Clipper quirk.)

It's a rare thing, but I was able to narrow it down to Clipper (v4.8.4), and a specific test polygon that I extracted from the test case. An earlier Clipper didn't produce the same error. And a very small change in one coordinate would make the problem go away. I've had similar experiences with winding reversals with Clipper negative offsets in a different project.

But the issue is avoided here if we skip the outset-inset cycle. It looks like that strategy developed to reduce some of the issues that are addressed by #720.

Maybe there's another purpose it serves that I can't see. If not, reducing that to just a union_ex() fixes this test case, and eliminates the risk of losing holes randomly in general.
