### PR TITLE
#718 Fragmented Self-overlapping "boxy" Perimeter

### DIFF
--- a/lib/Slic3r/Layer/Region.pm
+++ b/lib/Slic3r/Layer/Region.pm
@@ -89,12 +89,9 @@ sub make_surfaces {
         foreach my $surface (@surfaces) {
             push @{$self->slices}, map Slic3r::Surface->new
                 (expolygon => $_, surface_type => S_TYPE_INTERNAL),
-                @{union_ex([
-                    map @{$_},
-                        map $_->offset_ex(+$distance),
-                        $surface->expolygon->offset_ex(-2*$distance)
-                    ])
-                };
+                @{union_ex([Slic3r::Geometry::Clipper::offset(
+                    [Slic3r::Geometry::Clipper::offset($surface->expolygon, -2*$distance)],
+                    +$distance)])};
         }
         
         # now detect thin walls by re-outgrowing offsetted surfaces and subtracting
@@ -191,8 +188,9 @@ sub make_perimeters {
             # offsetting a polygon can result in one or many offset polygons
             my @new_offsets = ();
             foreach my $expolygon (@last_offsets) {
-                my @offsets = map $_->offset_ex(+0.5*$distance), $expolygon->offset_ex(-1.5*$distance);
-                @offsets = @{ union_ex([map {@{$_}} @offsets]) };
+                my @offsets = @{union_ex([Slic3r::Geometry::Clipper::offset(
+                                  [Slic3r::Geometry::Clipper::offset($expolygon, -1.5*$distance)], 
+                                  +0.5*$distance)])};
                 push @new_offsets, @offsets;
                 
                 my $diff = diff_ex(


### PR DESCRIPTION
I'm having a similar problem to #718, so I thought I'd address #718 first, then suggest an additional, similar fix for small gear teeth, and similar features.

Here's the section of #718's model that demonstrates the self-overlapping boxy perimeter, and the config I tested with:

http://sheldrake.net/bag/jhead_trouble_section.stl

http://sheldrake.net/bag/config_halfHeightFirstLayer.ini

Here's the problem:

![prob_feature_isolated_key_offsets.png](http://sheldrake.net/bag/prob_feature_isolated_key_offsets.png)

The part is roughly two extrusion widths wide. Because it's curved, and because it has the usual nightmare of close-together, non-smooth points, the initial -2x extrusion width offset from the part boundary results in multiple thin polygons, shown here in green. The following 1x extrusion width outset from these green lines gives the red overlapping boxes. These become the outer perimeter extrusion path.

If we just union the red boxes we get a better tool path, where the remaining problems should be addressed by improving the model and adjusting config settings.

The much more printable result after the union:

![prob_feature_isolated_after_union.png](http://sheldrake.net/bag/prob_feature_isolated_after_union.png)

Both the features in this test model are 1mm wide, and the config has perimeter width set to 0.5mm in the advanced settings. So that's kind of asking for trouble. When I tried setting the perimeter width to 0.495mm I got better results:

![prob_feature_isolated_after_union_smaller_width.png](http://sheldrake.net/bag/prob_feature_isolated_after_union_smaller_width.png)

Now the circle feature comes out two extrusions wide, like it should, instead of one. So the model and config are part of the problem in #718.

The overlapping perimeter sections revealed here are also possible in simpler, cleaner models that have curved or pocketed features with widths close to even multiples of extrusion width. And this issue applies to all perimeters, not just the outer one. 

Here's a spur gear example where the problem happens in the second perimeter, and the improved path obtained by applying a union to the results of the -1.5, +0.5 offset cycle in Region::make_perimeters()

![gear tooth example](http://sheldrake.net/bag/spur_bad_good.png)
http://sheldrake.net/bag/SPUR_mid.stl
http://sheldrake.net/bag/config_forspur.ini

Now the question is, did I mess up the gap filling feature this offset stuff helps with. I tried the test rake model from #281 with and without the two added unions, and the results look the same:

![rake okay before and after](http://sheldrake.net/bag/rake_okay.png)
