### PR TITLE
fix Can't locate object method "" via package "Slic3r::Config" at Slic3r...

### DIFF
--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -1171,6 +1171,9 @@ sub replace_options {
     $string =~ s/\[second\]/$lt[0]/eg;
     $string =~ s/\[version\]/$Slic3r::VERSION/eg;
     
+    # really not sure how this gets in here in the first place but it causes problems
+    delete $Slic3r::Config::Options->{''};
+    
     # build a regexp to match the available options
     my @options = grep !$Slic3r::Config::Options->{$_}{multiline},
         grep $self->has($_),


### PR DESCRIPTION
.../lib/Slic3r/Config.pm line 1175

It's line 1182 in current head.

first bad commit is 935173 - Allow [print_center_X] and [print_center_Y] syntax for all coordinates settings (including bed_center etc.) and [temperature_0], [temperature_1] etc. for all index-based settings

it's caused by %{$Slic3r::Config::Options} having an entry with a key of "" (empty string)

This pullreq is a workaround, not a solution for the issue.
