### PR TITLE
Forcing Perl to use English decimal point regardless current locales

### DIFF
--- a/slic3r.pl
+++ b/slic3r.pl
@@ -10,6 +10,7 @@ BEGIN {
 
 use Getopt::Long qw(:config no_auto_abbrev);
 use List::Util qw(first);
+$ENV{LC_NUMERIC} = 'en_US.UTF-8';
 use Slic3r;
 $|++;
 


### PR DESCRIPTION
Should correct invalid behavior on Perl >= 5.16
Didn't remove the warning, as it still needs more testing

`setlocale()` doesn't do the job, as it might be overwritten by any used module.

Probably needs some Windows test, as I am not sure, how this works there. Works fine on Linux.
