### PR TITLE
Export the last selected GUI configuration automatically.

### DIFF
--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -37,6 +37,7 @@ sub new {
             $self->{tabpanel},
             plater              => $self->{plater},
             on_value_change     => sub { $self->{plater}->on_config_change(@_) }, # propagate config change events to the plater
+            skeinpanel          => $self,
         );
         $self->{tabpanel}->AddPage($self->{options_tabs}{$tab_name}, $self->{options_tabs}{$tab_name}->title);
     }
@@ -186,6 +187,20 @@ sub export_config {
         $config->save($file);
     }
     $dlg->Destroy;
+}
+
+sub autoexport_config {
+    my $self = shift;
+    my $file = "$Slic3r::GUI::datadir/last_config.ini";
+
+    eval {
+	# FIXME. May fail if we are early in the initialisation, I
+	# need to understand why.
+	my $config = $self->config;
+
+        $config->validate;
+	$config->save($file);
+    };
 }
 
 sub load_config_file {

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -14,7 +14,7 @@ sub new {
     my ($parent, %params) = @_;
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, wxDefaultSize, wxBK_LEFT | wxTAB_TRAVERSAL);
     $self->{options} = []; # array of option names handled by this tab
-    $self->{$_} = $params{$_} for qw(plater on_value_change);
+    $self->{$_} = $params{$_} for qw(plater on_value_change skeinpanel);
     
     # horizontal sizer
     $self->{sizer} = Wx::BoxSizer->new(wxHORIZONTAL);
@@ -276,6 +276,7 @@ sub reload_values {
     my $self = shift;
     
     $self->set_value($_, $self->{config}->get($_)) for keys %{$self->{config}};
+    $self->{skeinpanel}->autoexport_config();
 }
 
 sub update_tree {


### PR DESCRIPTION
Avoids the annoying save, accept, export, accept pattern. Now you just
need to save. This is the first half of fixing issue #837. I have no
idea how to do a --loadlast option since the data directory path is
initialized in the GUI code and references WX code.

You may then do slic3r.pl --load ~/.Slic3r/last_config.ini
whatever.stl to slice with your last configuration.

More of a suggestion than a final patch.
