### PR TITLE
Finer Gap Filling until Medial Axis is used.

### DIFF
--- a/lib/Slic3r/Layer/Region.pm
+++ b/lib/Slic3r/Layer/Region.pm
@@ -290,12 +290,11 @@ sub make_perimeters {
             )};
             
             my $w = $self->perimeter_flow->width;
-			
             # 1.5 and 1.0 do nothing.  
-			# Anything 1.0 or bigger shoudl get filled with a single perimeter.  
-			# The settings below work really well, and almost completely fill the small slivers.
-			my @widths = (0.4 * $w, 0.04 * $w);  
-			foreach my $width (@widths) {
+            # Anything 1.0 or bigger shoudl get filled with a single perimeter.  
+            # The settings below work really well, and almost completely fill the small slivers.
+            my @widths = (0.4 * $w, 0.04 * $w);  
+            foreach my $width (@widths) {
                 my $flow = $self->perimeter_flow->clone(width => $width);
                 
                 # extract the gaps having this width


### PR DESCRIPTION
These gap filling settings almost completely fill even the finest gaps.

tested in printing and they work well.

my @widths = (1.5 \* $w, $w, 0.5 \* $w);  # worth trying 0.2 too?

![image](https://f.cloud.github.com/assets/203922/273454/b95f31a4-9024-11e2-987c-5c45c7f844a8.png)

I know you said 1.5 is worth using, but I can not find a test case where it actually gets used.  And why would it? anything 1.0 and larger gets filled with a single perimeter.

here is what I was using which works better
commit: f18f2782fc0b29f091e020595555c70e58e654c0
my @widths = (0.6 \* $w, 0.3 \* $w, 0.1 \* $w);  # worth trying 0.2 too?

![image](https://f.cloud.github.com/assets/203922/273483/eaaae270-9025-11e2-89fe-3b3ab4c6c332.png)

And here are the settings that I find to be the best at not leaving little holes between sizes (though you could probably leave off the 0.004 as that ends up being more a "stitching" action than an actuall filling:

commit: 768d410a2eff577cd8f8051200792b0fe95ba386
my @widths = (0.4 \* $w, 0.04 \* $w);

![image](https://f.cloud.github.com/assets/203922/273492/3a1511a0-9026-11e2-9ae4-4639c0d89f21.png)
