### PR TITLE
Adds a Support Gap option - fixes case when support extrusion width is very small

### DIFF
--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -633,6 +633,15 @@ our $Options = {
         type    => 'i',
         default => 0,
     },
+	'support_gap' => {
+        label   => 'Gap between model and support',
+        tooltip => 'Set this to a non-zero value to control the gap between the model and support material.  If expressed as a percentage (for example 90%) it will be a percentage of support extrusion width.',
+        sidetext => 'mm or % (leave 0 for default)',
+        cli     => 'support-gap=s',
+        type    => 'f',
+		ratio_over => 'layer_height',
+        default => '150%',
+    },
     'support_material_interface_layers' => {
         label   => 'Interface layers',
         tooltip => 'Number of interface layers to insert between the object(s) and support material.',

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -456,7 +456,7 @@ sub build {
     $self->add_options_page('Support material', 'building.png', optgroups => [
         {
             title => 'Support material',
-            options => [qw(support_material support_material_threshold support_material_enforce_layers)],
+            options => [qw(support_material support_material_threshold support_material_enforce_layers support_gap)],
         },
         {
             title => 'Raft',

--- a/lib/Slic3r/Print/Object.pm
+++ b/lib/Slic3r/Print/Object.pm
@@ -774,8 +774,15 @@ sub generate_support_material {
         Slic3r::debugf "Threshold angle = %d°\n", rad2deg($threshold_rad);
     }
     my $flow                    = $self->print->support_material_flow;
-    my $distance_from_object    = 1.5 * $flow->scaled_width;
-    my $pattern_spacing = ($Slic3r::Config->support_material_spacing > $flow->spacing)
+ 
+    #don't know where the scaling 1,000,000 should actually be done
+	#but since this is an absolute value now and not based on a scaled flow, and it's in mm 
+	#(or % of support extrusion width) so it had to be scaled up.
+	#this is important hack fix for the support gap for when support extrusion width is small, 
+	#without this, the support is built too close to the object.
+
+	my $distance_from_object    = $Slic3r::Config->get_value('support_gap') * 1000000; 
+	my $pattern_spacing = ($Slic3r::Config->support_material_spacing > $flow->spacing)
         ? $Slic3r::Config->support_material_spacing
         : $flow->spacing;
     


### PR DESCRIPTION
when the support extrusion width is very small, then support ends up printed too close to object and is very hard to remove.

Although this is not the ideal fix for the support problems, this is important when the support extrusion width is small to prevent support from being too close.

note - the default is set to 150% of support extrusion width, so it should match your original math.

Another note, which is unfortunate, I don't know how to scale the value by the 1,000,000 that the $flow->scaled_width was scaled to... so it's hard-coded.

anyway, hope this is helpful.
