### PR TITLE
Only shift objects in Z if min z is below zero.  If Z is above zero leave alone

### DIFF
--- a/lib/Slic3r/Geometry.pm
+++ b/lib/Slic3r/Geometry.pm
@@ -715,6 +715,11 @@ sub bounding_box_3D {
             $extents[$_][MAX] = $point->[$_] if !defined $extents[$_][MAX] || $point->[$_] > $extents[$_][MAX];
         }
     }
+    #if the bottom of the object is above zero, it's probably for a reason?
+    #then again, it's possible we'll want to move to ground, so how can we do either?
+    Slic3r::debugf "If bottom extent ( %.2f ) is > 0.0, then replace with 0.0 to prevent dropping - now it's ",$extents[Z][MIN] ;
+    $extents[Z][MIN] = ($extents[Z][MIN] > 0) ? 0 : $extents[Z][MIN];
+    Slic3r::debugf "%.2f \n",$extents[Z][MIN] ;
     return @extents;
 }
 


### PR DESCRIPTION
Slic3r, moves all newly imported objects, and new objects created by split, so that their bounding box minimum Z is at 0.

Obviously we don't want points below 0, so we should continue to move objects up to 0 on import.

However, if the object is above 0 already, we should probably handle separately, the moving of the object so extents[Z][MIN]=0.  e.g. using a new BUTTON called "Drop"

For objects with multiple separate volumes, we may want to split them in-place. 
slic3r current splits them, finds the bounding box and moves each objects so that etents[Z][MIN] = 0.

When splitting a multi-part object we may actually want to maintain their position.  For example, if we wanted to specify different materials like - abs for a hing, and pla for the two halves of a box.  or a manual support region and the object.

I'm sure there are other cases as well.

the only drawback to my implementation here is that 1) it's not the true bounding box returned unless the object is below 0.  and if you did want to drop all objects so min Z is 0, I haven't provided a way to do so (limits of my perl skill)

This is less of an immediate pull request, as - help, I'm trying to do something useful to Slic3r, but am stuck.  :)

let me know - I now know most of the places the align_to_origin and move are used, and more or less know what's happening, but not how to modify... very much. :)
