### PR TITLE
Performance improvement for nearest_point_index

### DIFF
--- a/lib/Slic3r/Geometry.pm
+++ b/lib/Slic3r/Geometry.pm
@@ -243,8 +243,12 @@ sub nearest_point_index {
     my ($point, $points) = @_;
     
     my ($nearest_point_index, $distance) = ();
+
+    my $point_x = $point->[X];
+    my $point_y = $point->[Y];
+
     for my $i (0..$#$points) {
-        my $d = (($point->[X] - $points->[$i]->[X])**2) + (($point->[Y] - $points->[$i]->[Y])**2);
+        my $d = (($point_x - $points->[$i]->[X])**2) + (($point_y - $points->[$i]->[Y])**2);
         if (!defined $distance || $d < $distance) {
             $nearest_point_index = $i;
             $distance = $d;


### PR DESCRIPTION
I was trying to slice a rather large model with honeycomb infill today. After about 20 minutes, it was still maxing out my CPU. After a bit of playing around in nytprof, I found that inlining comparable_distance_between_points (and then a few further tweaks) was a huge performance boost. Those tiny method calls and object lookups really start to add up pretty quickly.

Converting my sample .stl, I see a 20% decrease in runtime of slic3r.pl. Across the slic3r test suite (which I know isn't a performance test suite), I see a more modest 7% drop.
