### PR TITLE
Nearest point index perf work part 2

### DIFF
--- a/lib/Slic3r/Geometry.pm
+++ b/lib/Slic3r/Geometry.pm
@@ -248,13 +248,22 @@ sub nearest_point_index {
     my $point_y = $point->[Y];
 
     for my $i (0..$#$points) {
-        my $d = (($point_x - $points->[$i]->[X])**2) + (($point_y - $points->[$i]->[Y])**2);
-        if (!defined $distance || $d < $distance) {
-            $nearest_point_index = $i;
-            $distance = $d;
-            last if $distance < epsilon;
-        }
+        my $d = ($point_x - $points->[$i]->[X])**2;
+        # If the X distance of the candidate is > than the total distance of the
+        # best previous candidate, we know we don't want it
+        next if (defined $distance && $d > $distance);
+   
+        # If the total distance of the candidate is > than the total distance of the
+        # best previous candidate, we know we don't want it
+        $d += ($point_y - $points->[$i]->[Y])**2;
+        next if (defined $distance && $d > $distance);
+
+        $nearest_point_index = $i;
+        $distance = $d;
+        
+        last if $distance < epsilon;
     }
+
     return $nearest_point_index;
 }
 


### PR DESCRIPTION
By splitting apart the math, we cut down on method calls and multiplication inside a tight loop. This one is a little bit more contentious and I won't cry if you reject it out of hand but it does win me an additional 10% perf boost  (on top of my previous pull request.)  
