### PR TITLE
Set LC_NUMERIC to C explicitly

### DIFF
--- a/slic3r.pl
+++ b/slic3r.pl
@@ -10,6 +10,7 @@ BEGIN {
 
 use Getopt::Long qw(:config no_auto_abbrev);
 use List::Util qw(first);
+use POSIX qw(setlocale LC_NUMERIC);
 use Slic3r;
 $|++;
 
@@ -84,6 +85,7 @@ if (!@ARGV && !$opt{save} && eval "require Slic3r::GUI; 1") {
         $Slic3r::GUI::autosave  = $opt{autosave};
     }
     $gui = Slic3r::GUI->new;
+    setlocale(LC_NUMERIC, 'C');
     $gui->{skeinpanel}->load_config_file($_) for @{$opt{load}};
     $gui->{skeinpanel}->load_config($cli_config);
     $gui->MainLoop;


### PR DESCRIPTION
Wx library sets LC_NUMERIC to current locale (for me it is pl_PL) and then all numbers generated (printed, dumped, stored as hash keys) contains comma rather than dot.

Wx version: 0.9922

It provokes some errors like:

Argument "9,5" isn't numeric in sort at /home/dexter/src/slic3r/master/lib/Slic3r/Print.pm line 877.

And other errors are more subtle (bad gcode output).

Demonstration for LC_NUMERIC:

$ LC_ALL=pl_PL.UTF-8 perl -MPOSIX=setlocale,LC_NUMERIC -le 'setlocale LC_NUMERIC, ""; $a = 8/7; $h{$a}=1; $i = (keys %h)[0]; printf "%f\t%f\n", $i, POSIX::strtod($i)  '
1,000000    1,142857

Solution;

Reset LC_NUMERIC back to "C" after Wx app is created.
