### PR TITLE
Instead of dying if the file is not a recognized format, warn the user and continue

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -383,6 +383,12 @@ sub load_file {
     
     local $SIG{__WARN__} = Slic3r::GUI::warning_catcher($self);
     my $model = Slic3r::Model->read_from_file($input_file);
+    if( !defined $model ) {
+        $process_dialog->Destroy;
+        $self->statusbar->SetStatusText("Unrecognized file format");
+        return;
+    }
+
     $self->load_model_object($_) for @{$model->objects};
     
     $process_dialog->Destroy;

--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -135,6 +135,12 @@ sub quick_slice {
         
         my $print = $self->init_print;
         my $model = Slic3r::Model->read_from_file($input_file);
+
+        if( !defined $model ) {
+            Wx::MessageDialog->new( $self, "Invalid file format.",
+                                    'Error', wxICON_ERROR | wxOK )->ShowModal();
+            return;
+        }
         
         if ($model->has_objects_with_no_instances) {
             # apply a default position to all objects not having one
@@ -375,6 +381,13 @@ sub combine_stls {
     }
     
     my @models = map Slic3r::Model->read_from_file($_), @input_files;
+    @models = grep { defined $_ } @models;
+    if( scalar @models <= 0 ) {
+        Wx::MessageDialog->new( $self, "No valid models were found.",
+                                'Error', wxICON_ERROR | wxOK )->ShowModal();
+        return;
+    }
+
     my $new_model = Slic3r::Model->new;
     my $new_object = $new_model->add_object;
     for my $m (0 .. $#models) {

--- a/lib/Slic3r/Model.pm
+++ b/lib/Slic3r/Model.pm
@@ -14,9 +14,12 @@ sub read_from_file {
     my $model = $input_file =~ /\.stl$/i            ? Slic3r::Format::STL->read_file($input_file)
               : $input_file =~ /\.obj$/i            ? Slic3r::Format::OBJ->read_file($input_file)
               : $input_file =~ /\.amf(\.xml)?$/i    ? Slic3r::Format::AMF->read_file($input_file)
-              : die "Input file must have .stl, .obj or .amf(.xml) extension\n";
+              : undef;
+    warn "Input file must have .stl, .obj or .amf(.xml) extension\n" unless defined $model;
     
-    $_->input_file($input_file) for @{$model->objects};
+    if(defined $model) {
+        $_->input_file($input_file) for @{$model->objects};
+    }
     return $model;
 }
 

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -116,9 +116,12 @@ if (@ARGV) {  # slicing from command line
         my $model;
         if ($opt{merge}) {
             my @models = map Slic3r::Model->read_from_file($_), $input_file, (splice @ARGV, 0);
+            @models = grep { defined $_ } @models;
+            die( "no valid modules loaded" ) unless scalar @models > 0;
             $model = Slic3r::Model->merge(@models);
         } else {
             $model = Slic3r::Model->read_from_file($input_file);
+            die( "unrecognized file format" ) unless defined $model;
         }
         
         my $need_arrange = $model->has_objects_with_no_instances;

--- a/utils/view-mesh.pl
+++ b/utils/view-mesh.pl
@@ -26,6 +26,7 @@ my %opt = ();
 
 {
     my $model = Slic3r::Model->read_from_file($ARGV[0]);
+    die( "no model loaded" ) unless defined $model;
     
     $Slic3r::ViewMesh::object = $model->objects->[0];
     my $app = Slic3r::ViewMesh->new;


### PR DESCRIPTION
Yeah, I sometimes try to load an old .gcode instead of the .stl to make a new slicing. Which is silly. But it's also silly that Slic3r die()s when this happens.

Patch makes this a non-fatal condition in read_from_file and handles the error where read_from_file is called.
