### PR TITLE
fixed simple config load bug

### DIFF
--- a/lib/Slic3r/GUI/SimpleTab.pm
+++ b/lib/Slic3r/GUI/SimpleTab.pm
@@ -71,7 +71,7 @@ sub load_config {
     my $self = shift;
     my ($config) = @_;
     
-    foreach my $opt_key (grep $self->{config}->has($_), keys %$config) {
+    foreach my $opt_key (grep $self->{config}->has($_), @{$config->get_keys}) {
         my $value = $config->get($opt_key);
         $self->{config}->set($opt_key, $value);
         $_->set_value($opt_key, $value) for @{$self->{optgroups}};


### PR DESCRIPTION
Seems to fix issue #1723.  Looks like the configuration data structure changed from a hash to a class, and the simple configuration load routine was not updated.   Please note I did not delve into the code to bless this fix... take this pull request as more of a pointer to where the problem probably is...
