### PR TITLE
Disable some calls to on_presets_changed to speed up switching profiles

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -311,6 +311,9 @@ sub update_tree {
 sub set_dirty {
     my $self = shift;
     my ($dirty) = @_;
+
+    return if $dirty and $self->is_dirty;
+    return if (not $dirty) and (not $self->is_dirty);
     
     my $selection = $self->{presets_choice}->GetSelection;
     my $i = $self->{dirty} // $selection; #/


### PR DESCRIPTION
By profiling I found that most of the time switching profiles is spent in calls to on_presets_changed, rebuilding the presets list.

I tried turning off 2 points in the code that seem to be responsible for most of it. I hope they're not important to keep. It seems to help a lot - I now get around 2 seconds to swap or save profiles, instead of 27, with profiling on.
