### PR TITLE
Allow for both nozzles to be purged every layer

### DIFF
--- a/lib/Slic3r/GCode/Layer.pm
+++ b/lib/Slic3r/GCode/Layer.pm
@@ -89,6 +89,14 @@ sub process_layer {
             for my $i (0 .. $#skirt_loops) {
                 # when printing layers > 0 ignore 'min_skirt_length' and 
                 # just use the 'skirts' setting; also just use the current extruder
+                if ($extruder_ids[-1] == 1) {
+                    if ($i <= $#skirt_loops/2) {
+                        $gcode .= $self->gcodegen->set_extruder($extruder_ids[0]);
+                    }
+                    if ($i > $#skirt_loops/2) {
+                        $gcode .= $self->gcodegen->set_extruder($extruder_ids[1]);
+                    }
+                }
                 last if ($layer->id > 0) && ($i >= $self->print->config->skirts);
                 $gcode .= $self->gcodegen->set_extruder(($i/@extruder_ids) % @extruder_ids)
                     if $layer->id == 0;


### PR DESCRIPTION
While this is not an absolute fix, as more than 2 nozzles would not be supported, it would purge the two first nozzles every layer.

A better fix would to send nozzle[i] to skirt immediately before printing out nozzle[i]'s support/perimeter/infill/etc. This would purge the nozzle immediately before you print to the main model.

ie:
for layer i:
  support nozzle[1] -> skirt nozzle[1]
  print skirt nozzle[1]
  print support nozzle[1]
  perimeter nozzle [0] -> skirt nozzle[0]
  print skirt nozzle[0]
  print perimeter nozzle[0]
  print infill nozzle[0]
  i++

Not sure how to do this, but it would be a great addition.

Thank you,
TJ Mustard