### PR TITLE
add --sudo flag

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -27,6 +27,7 @@ my %recommends = qw(
     XML::SAX::ExpatXS               0
 );
 
+my $sudo    = grep { $_ eq '--sudo' } @ARGV;
 my $gui     = grep { $_ eq '--gui' } @ARGV;
 my $xs_only = grep { $_ eq '--xs' }  @ARGV;
 if ($gui) {
@@ -89,19 +90,21 @@ If it is installed in a non-standard location you can do:
 
 EOF
         if !$cpanm;
-    
+    my @cpanm_args = ();
+    push @cpanm_args, "--sudo" if $sudo;
+
     # make sure our cpanm is updated (old ones don't support the ~ syntax)
-    system $cpanm, 'App::cpanminus';
+    system $cpanm, @cpanm_args, 'App::cpanminus';
     
     # install the Windows-compatible Math::Libm
     if ($^O eq 'MSWin32' && !eval "use Math::Libm; 1") {
-        system $cpanm, 'https://github.com/alexrj/Math-Libm/tarball/master';
+        system $cpanm, @cpanm_args, 'https://github.com/alexrj/Math-Libm/tarball/master';
     }
     
     my %modules = (%prereqs, %recommends);
     foreach my $module (sort keys %modules) {
         my $version = $modules{$module};
-        my @cmd = ($cpanm, "$module~$version");
+        my @cmd = ($cpanm, @cpanm_args, "$module~$version");
         if ($module eq 'XML::SAX::ExpatXS' && $^O eq 'MSWin32') {
             my $mingw = 'C:\dev\CitrusPerl\mingw64';
             $mingw = 'C:\dev\CitrusPerl\mingw32' if !-d $mingw;
@@ -131,7 +134,7 @@ EOF
                 system './xs/Build', 'distclean';
             }
         }
-        my $res = system $cpanm, '--reinstall', './xs';
+        my $res = system $cpanm, @cpanm_args, '--reinstall', './xs';
         if ($res != 0) {
             die "The XS/C++ code failed to compile, aborting\n";
         }


### PR DESCRIPTION
This adds --sudo flag to Build.PL. This flag is passed to cpanm, so it is possible to build Slicer on linux without beeing root (build files are owned by user)
