### PR TITLE
Add importing of ini config from verbose gcode

### DIFF
--- a/lib/Slic3r/GUI/SkeinPanel.pm
+++ b/lib/Slic3r/GUI/SkeinPanel.pm
@@ -20,6 +20,7 @@ use constant FILE_WILDCARDS => {
     obj     => 'OBJ files (*.obj)|*.obj;*.OBJ',
     amf     => 'AMF files (*.amf)|*.amf;*.AMF;*.xml;*.XML',
     ini     => 'INI files *.ini|*.ini;*.INI',
+    inigco  => 'INI or G-code files (*.ini, *.gcode, *.gco, *.g, *.ngc)|*.ini;*.INI;*.gcode;*.GCODE;*.gco;*.GCO;*.g;*.G;*.ngc;*.NGC',
     gcode   => 'G-code files (*.gcode, *.gco, *.g, *.ngc)|*.gcode;*.GCODE;*.gco;*.GCO;*.g;*.G;*.ngc;*.NGC',
     svg     => 'SVG files *.svg|*.svg;*.SVG',
 };
@@ -276,7 +277,7 @@ sub load_config_file {
         return unless $self->check_unsaved_changes;
         my $dir = $last_config ? dirname($last_config) : $Slic3r::GUI::Settings->{recent}{config_directory} || $Slic3r::GUI::Settings->{recent}{skein_directory} || '';
         my $dlg = Wx::FileDialog->new($self, 'Select configuration to load:', $dir, "config.ini", 
-                FILE_WILDCARDS->{ini}, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                FILE_WILDCARDS->{inigco}, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
         return unless $dlg->ShowModal == wxID_OK;
         ($file) = $dlg->GetPaths;
         $dlg->Destroy;


### PR DESCRIPTION
It's works as well as I think it could do with the current output format of verbose gcode. It's not catastrophically slow, I tested on up to a 35MB file. It will die with a useful message if the gcode file doesn't have a config, not useful to GUI users, much like invalid ini files.

I think it would be a wise to next add ini configs to the end of all gcode with a nice start and end header.
