### PR TITLE
Raft/support is generated too low under object in 1.1.2 (patch fixes it)

### DIFF
--- a/lib/Slic3r/Print/Object.pm
+++ b/lib/Slic3r/Print/Object.pm
@@ -118,7 +118,6 @@ sub slice {
     
         # make layers taking custom heights into account
         my $print_z = my $slice_z = my $height = my $id = 0;
-        my $first_object_layer_height = -1;
     
         # add raft layers
         if ($self->config->raft_layers > 0) {
@@ -136,7 +135,7 @@ sub slice {
         
             # force first layer print_z according to the contact distance
             # (the loop below will raise print_z by such height)
-            $first_object_layer_height = $distance;
+            $print_z += $distance;
         }
     
         # loop until we have at least one layer and the max slice_z reaches the object height
@@ -156,10 +155,6 @@ sub slice {
                     $slice_z += $range->[1] - $range->[0];
                     next;
                 }
-            }
-            
-            if ($first_object_layer_height != -1 && !@{$self->layers}) {
-                $height = $first_object_layer_height;
             }
             
             $print_z += $height;


### PR DESCRIPTION
Hi!

I've started to use Slic3r and noticed that raft/support is almost totally unusable, because it's generated 0.6mm under object material which makes it not stick to the raft/support.
The problems were:
1) 0.6mm contact_distance (0.4mm nozzle diameter \* 1.5) is too big - that's 3 layers in case of 0.2mm layer! Also too bad it's hardcoded now, maybe 0.2 or 0.1 could be useful... So this patch changes it to logically just be "distance from support to object" instead of "layer height + distance from support to object", and makes the code work with any setting (i.e. you can set 0 and it will work and you can set 0.2 and it will also work)... So it should be possible to make it a configured parameter in later patches :)
2) I think the support layer height should be equal to object layer height... and what's more important, the RAFT layer height to be equal to object layer height so it can be aligned with the object... Again, I think support layer height should be configurable - maybe the another parameter should be also added...
3) printing with both raft and support, and without manually specified overhang angle, is totally broken - Slic3r tries to generate support material for ALL layers in that case. This was caused by the "different logic" of overhang detection that doesn't work if $d == 0...
4) IMHO that "different logic" isn't needed at all - as I understand it generates "inner" support instead of "outer", and I don't understand why the manual threshold angle, or presence of raft, or enforced support for first N layers should change the support generation algorithm that much... I think manually specified angle should just be manually specified angle, without any additional logic changes. So the patch removes it which also fixes (3)...

These bugs are kind of intermixed and depend on each other so I submit the fixes mixed up in one patch... I can try to subdivide them if that's needed...

By the way, thanks for your work, and I'm also happy you've done it in perl+xs because I'm also a perlist :))
