### PR TITLE
Call get_layer instead of layers->[] (more efficient)

### DIFF
--- a/lib/Slic3r/Print.pm
+++ b/lib/Slic3r/Print.pm
@@ -479,7 +479,7 @@ sub process {
                 my $q = shift;
                 while (defined (my $obj_layer = $q->dequeue)) {
                     my ($i, $region_id) = @$obj_layer;
-                    my $layerm = $object->layers->[$i]->regions->[$region_id];
+                    my $layerm = $object->get_layer($i)->regions->[$region_id];
                     $layerm->fills->clear;
                     $layerm->fills->append( $object->fill_maker->make_fill($layerm) );
                 }
@@ -668,7 +668,7 @@ sub make_skirt {
             ? scalar(@{$object->layers})
             : min($self->config->skirt_height, scalar(@{$object->layers}));
         
-        my $highest_layer = $object->layers->[$skirt_height-1];
+        my $highest_layer = $object->get_layer($skirt_height - 1);
         $skirt_height_z = max($skirt_height_z, $highest_layer->print_z);
     }
     
@@ -781,7 +781,7 @@ sub make_brim {
     my @islands = (); # array of polygons
     foreach my $obj_idx (0 .. ($self->object_count - 1)) {
         my $object = $self->objects->[$obj_idx];
-        my $layer0 = $object->layers->[0];
+        my $layer0 = $object->get_layer(0);
         my @object_islands = (
             (map $_->contour, @{$layer0->slices}),
         );

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -111,7 +111,7 @@ sub contact_area {
             # the 'overhangs' of the first object layer
             last if $layer_id > 0;
         }
-        my $layer = $object->layers->[$layer_id];
+        my $layer = $object->get_layer($layer_id);
         
         # detect overhangs and contact areas needed to support them
         my (@overhang, @contact) = ();
@@ -122,7 +122,7 @@ sub contact_area {
             push @overhang, map $_->clone, map $_->contour, @{$layer->slices};
             push @contact, @{offset(\@overhang, scale +MARGIN)};
         } else {
-            my $lower_layer = $object->layers->[$layer_id-1];
+            my $lower_layer = $object->get_layer($layer_id-1);
             foreach my $layerm (@{$layer->regions}) {
                 my $fw = $layerm->flow(FLOW_ROLE_EXTERNAL_PERIMETER)->scaled_width;
                 my $diff;


### PR DESCRIPTION
`layers` now recreates the array, so this made looping over layers with `layers->[$i]` be O(n^2)

The semantics of get_layer are slightly different though, because it a. doesn't support negative indices, and b. throws a C++ exception if the index is invalid, instead of returning undef.
