### PR TITLE
Fix automatic overhang threshold

### DIFF
--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -152,7 +152,7 @@ sub contact_area {
                 } else {
                     $diff = diff(
                         [ map $_->p, @{$layerm->slices} ],
-                        offset([ map @$_, @{$lower_layer->slices} ], +$fw*2),
+                        offset([ map @$_, @{$lower_layer->slices} ], +$fw/2),
                     );
                 
                     # collapse very tiny spots


### PR DESCRIPTION
We should be supporting perimeters that are overhung further than half a
perimeter out, rather than two times the perimeter width.

Fixes: #2068
