### PR TITLE
Update 2DToolpaths.pm

### DIFF
--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -23,7 +23,7 @@ sub new {
         $self, -1,
         0,                              # default
         0,                              # min
-        0,                              # max
+        1,                              # max
         wxDefaultPosition,
         wxDefaultSize,
         wxVERTICAL | wxSL_INVERSE,


### PR DESCRIPTION
This will make the slider show up. Because the maximum number was set to zero before there was a problem.

Regards,

Glen Charles Rowell
