### PR TITLE
Update 2DToolpaths.pm

### DIFF
--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -292,7 +292,7 @@ sub Render {
         }
     }
     
-    gluDeleteTess($tess);
+    #gluDeleteTess($tess);
     glFlush();
     $self->SwapBuffers;
 }


### PR DESCRIPTION
Hello ^^

This will show the missing toolpath preview again. Please comment out line 295 for now.

lib/Slic3r/GUI/Plater/2DToolpaths.pm
# gluDeleteTess($tess);

Thank you.

Regards,

Glen Charles Rowell
