### PR TITLE
I suggest using "perl Build.PL --sudo" instead of "sudo perl Build.PL" in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ If you want to compile the source yourself just do the following (checkout
 ```
 $ git clone https://github.com/alexrj/Slic3r.git
 $ cd Slic3r
-$ sudo perl Build.PL
-$ sudo perl Build.PL --gui
+$ perl Build.PL --sudo
+$ perl Build.PL --sudo --gui
 $ ./slic3r.pl
 ```
 


### PR DESCRIPTION
Hello !
I suggest using `perl Build.PL --sudo` instead of `sudo perl Build.PL` in the README file.
The rationale being twofold:
* running `sudo perl Build.PL` leaves root-owned files in your local repository, if that is owned by a regular user it might be cumbersome to e.g. clean afterwards.
* for security purposes it's IMHO better to run only parts of the process with elevated privileges instead of the whole one

what do you think ?
Thanks for Slic3r btw :)
