### PR TITLE
Use std::getline to deserialize point list coords, fixes #2318

### DIFF
--- a/xs/src/libslic3r/Config.hpp
+++ b/xs/src/libslic3r/Config.hpp
@@ -295,18 +295,21 @@ class ConfigOptionPoints : public ConfigOption, public ConfigOptionVector<Pointf
     };
     
     bool deserialize(std::string str) {
-        std::vector<Pointf> values;
+        this->values.clear();
         std::istringstream is(str);
         std::string point_str;
         while (std::getline(is, point_str, ',')) {
             Pointf point;
             std::istringstream iss(point_str);
-            iss >> point.x;
-            iss.ignore(std::numeric_limits<std::streamsize>::max(), 'x');
-            iss >> point.y;
-            values.push_back(point);
+            std::string coord_str;
+            if (std::getline(iss, coord_str, 'x')) {
+                std::istringstream(coord_str) >> point.x;
+                if (std::getline(iss, coord_str, 'x')) {
+                    std::istringstream(coord_str) >> point.y;
+                }
+            }
+            this->values.push_back(point);
         }
-        this->values = values;
         return true;
     };
 };


### PR DESCRIPTION
For some reason, Yosemite handles iostream `>>` number parsing differently than other platforms. Here's a demonstration:

```cpp
#include <stdio.h>
#include <limits>
#include <iostream>
#include <sstream>

int main( ) {
  double x = 0;
  double y = 0;
  std::string point_str("4x5");
  std::istringstream iss(point_str);

  // Gives "0,0" on Yosemite, current Slic3r implementation
  iss >> x;
  iss.ignore(std::numeric_limits<std::streamsize>::max(), 'x');
  iss >> y;
  std::cout << x << "," << y << std::endl;

  iss.clear();
  iss.str(point_str);
  x = 0;
  y = 0;

  // Works on Yosemite (and others)
  std::string coord_str;
  if (std::getline(iss, coord_str, 'x')) {
      std::istringstream(coord_str) >> x;
      if (std::getline(iss, coord_str, 'x')) {
          std::istringstream(coord_str) >> y;
      }
  }
  std::cout << x << "," << y << std::endl;
}
```

I don't know what controls this behavior, but `iss >> x` doesn't pass the value to `x` if the failbit gets set by the formatted extraction (which it will because of the `x`). I thought that was a locale thing, but the stream locales and their flags match up on Yosemite and Ubuntu for me, but the behavior is different. Pretty weird.