### PR TITLE
Fix a warning about unused return value when using freopen in admesh.

### DIFF
--- a/xs/src/admesh/stlinit.c
+++ b/xs/src/admesh/stlinit.c
@@ -135,7 +135,21 @@ stl_count_facets(stl_file *stl, char *file) {
   /* Otherwise, if the .STL file is ASCII, then do the following */
   else {
     /* Reopen the file in text mode (for getting correct newlines on Windows) */
-    freopen(file, "r", stl->fp);
+    // fix to silence a warning about unused return value.
+    // obviously if it fails we have problems....
+    stl->fp = freopen(file, "r", stl->fp);
+
+    // do another null check to be safe
+    if(stl->fp == NULL) {
+      error_msg = (char*)
+        malloc(81 + strlen(file)); /* Allow 80 chars+file size for message */
+      sprintf(error_msg, "stl_initialize: Couldn't open %s for reading",
+          file);
+      perror(error_msg);
+      free(error_msg);
+      stl->error = 1;
+      return;
+    }
     
     /* Find the number of facets */
     j = 0;


### PR DESCRIPTION
Also added another NULL check for safety. This is to fix a warning provided by gcc 4.9.1

While the reopen *should* be safe, weird things can still happen so we shouldn't assume that it is safe (or that the fp is the same). 