### PR TITLE
Remove redundant dep on ExtUtils::Typemap

### DIFF
--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -29,7 +29,7 @@ my $build = Module::Build::WithXSpp->new(
     dist_abstract   => 'XS code for Slic3r',
     build_requires => {qw(
         ExtUtils::ParseXS           3.18
-        ExtUtils::Typemap           1.00
+        ExtUtils::Typemaps          1.00
         ExtUtils::Typemaps::Default 1.05
         ExtUtils::XSpp              0.17
         Module::Build               0.3601


### PR DESCRIPTION
 Typemap (Singluar) version 1.00 is essentially identical to Typemaps (Plural)
 Typemap is literally a dumb subclass of TypeMaps, and so this
 dependency simply gives an extra installation requirement that does
 nothing.

See how all of the below are basically just `package Foo; @ISA = Foos ` 
https://metacpan.org/source/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap.pm
https://metacpan.org/source/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap/InputMap.pm
https://metacpan.org/source/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap/OutputMap.pm
https://metacpan.org/source/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap/Type.pm

