### PR TITLE
Bugfix: correctly draw circular beds in the 2D plater

### DIFF
--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -77,7 +77,7 @@ sub repaint {
     
     # draw grid
     $dc->SetPen($self->{grid_pen});
-    $dc->DrawLine(map @$_, @$_) for @{$self->{grid}};
+    $dc->DrawLines([map $_, @$_]) for @{$self->{grid}};
     
     # draw bed
     {


### PR DESCRIPTION
Wx::DrawLine wasn't happy with a polyline, so we pass the sequence of points to Wx::DrawLines