### PR TITLE
Adding velocity extrusion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The author of the Silk icon set is Mark James.
         --use-relative-e-distances Enable this to get relative E values (default: no)
         --use-firmware-retraction  Enable firmware-controlled retraction using G10/G11 (default: no)
         --use-volumetric-e  Express E in cubic millimeters and prepend M200 (default: no)
+        --use-velocity-extrusion Express E in velocity mode using the M600 command (default: no)
         --gcode-arcs        Use G2/G3 commands for native arcs (experimental, not supported
                             by all firmwares)
         --gcode-comments    Make G-code verbose by adding comments (default: no)

--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -242,7 +242,7 @@ sub validate {
     die "Invalid value for --gcode-flavor\n"
         if !first { $_ eq $self->gcode_flavor } @{$Options->{gcode_flavor}{values}};
     
-    die "--use-firmware-retraction is only supported by Marlin firmware\n"
+    die "--use-firmware-retraction is only supported by Marlin and Machinekit firmware\n"
         if $self->use_firmware_retraction && $self->gcode_flavor ne 'reprap' && $self->gcode_flavor ne 'machinekit';
     
     die "--use-firmware-retraction is not compatible with --wipe\n"

--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -247,6 +247,13 @@ sub validate {
     
     die "--use-firmware-retraction is not compatible with --wipe\n"
         if $self->use_firmware_retraction && first {$_} @{$self->wipe};
+
+    # --use-velocity-extrusion
+    die "--use-velocity-extrusion is only supported by Machinekit firmware\n"
+        if $self->use_velocity_extrusion && $self->gcode_flavor ne 'machinekit';
+
+    die "--use-velocity-extrusion must be used in combination with --use-firmware-retraction\n"
+        if $self->use_velocity_extrusion && !$self->use_firmware_retraction;
     
     # --fill-pattern
     die "Invalid value for --fill-pattern\n"

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -274,8 +274,10 @@ sub _extrude_path {
     }
     
     # calculate extrusion length per distance unit
-    my $e_per_mm = $self->writer->extruder->e_per_mm3 * $path->mm3_per_mm;
-    $e_per_mm = 0 if !$self->writer->extrusion_axis;
+    my $mm3_per_mm = $path->mm3_per_mm;
+    $mm3_per_mm = 0 if !$self->writer->extrusion_axis;
+
+    
     
     # set speed
     $speed //= -1;
@@ -309,7 +311,7 @@ sub _extrude_path {
     my $path_length = unscale $path->length;
     {
         my $extruder_offset = $self->config->get_at('extruder_offset', $self->writer->extruder->id);
-        $gcode .= $path->gcode($self->writer->extruder, $e_per_mm, $F,
+        $gcode .= $path->gcode($self->writer->extruder, $mm3_per_mm, $F,
             $self->origin->x - $extruder_offset->x,
             $self->origin->y - $extruder_offset->y,  #-
             $self->writer->extrusion_axis,

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -311,7 +311,7 @@ sub _extrude_path {
     my $path_length = unscale $path->length;
     {
         my $extruder_offset = $self->config->get_at('extruder_offset', $self->writer->extruder->id);
-        $gcode .= $path->gcode($self->writer->extruder, $mm3_per_mm, $F,
+        $gcode .= $path->gcode($self->writer, $mm3_per_mm, $F,
             $self->origin->x - $extruder_offset->x,
             $self->origin->y - $extruder_offset->y,  #-
             $self->writer->extrusion_axis,

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -279,7 +279,7 @@ sub _extrude_path {
 
     if (($mm3_per_mm > 0) && $self->config->use_velocity_extrusion) {
         $gcode .= $self->writer->set_cross_section($mm3_per_mm,
-                                                   $self->config->gcode_comments ? " ; $description" : "");
+                                                   $description);
         $mm3_per_mm = 0;
     }
 
@@ -319,7 +319,7 @@ sub _extrude_path {
             $self->origin->x - $extruder_offset->x,
             $self->origin->y - $extruder_offset->y,  #-
             $self->writer->extrusion_axis,
-            $self->config->gcode_comments ? " ; $description" : "");
+            $description);
 
         if ($self->wipe->enable) {
             $self->wipe->path($path->polyline->clone);

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -222,8 +222,12 @@ sub extrude_loop {
         my $point = $first_segment->point_at($distance);
         $point->rotate($angle, $first_segment->a);
         
-        # generate the travel move
-        $gcode .= $self->writer->travel_to_xy($self->point_to_gcode($point), "move inwards before travel");
+        # generate the travel move, usually unretracted -> also set cross section
+        my $comment = "move inwards before travel";
+        if ($self->config->use_velocity_extrusion) {
+            $gcode .= $self->writer->set_cross_section(0.0, $comment);
+        }
+        $gcode .= $self->writer->travel_to_xy($self->point_to_gcode($point), $comment);
     }
     
     return $gcode;

--- a/lib/Slic3r/GCode/PressureRegulator.pm
+++ b/lib/Slic3r/GCode/PressureRegulator.pm
@@ -43,7 +43,7 @@ sub process {
                 my $rel_flow_rate = $info->{dist_E} / $info->{dist_XY};
             
                 # Then calculate absolute flow rate (mm/sec of feedstock)
-                my $flow_rate = $rel_flow_rate * $args->{F} / 60;
+                my $flow_rate = $rel_flow_rate * $F / 60;
             
                 # And finally calculate advance by using the user-configured K factor.
                 my $new_advance = $self->config->pressure_advance * ($flow_rate**2);

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -951,7 +951,7 @@ sub build {
         gcode_flavor use_relative_e_distances
         octoprint_host octoprint_apikey
         use_firmware_retraction pressure_advance vibration_limit
-        use_volumetric_e
+        use_volumetric_e use_velocity_extrusion
         start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode
         nozzle_diameter extruder_offset
         retract_length retract_lift retract_speed retract_restart_extra retract_before_travel retract_layer_change wipe
@@ -1092,6 +1092,7 @@ sub build {
             $optgroup->append_single_option_line('use_relative_e_distances');
             $optgroup->append_single_option_line('use_firmware_retraction');
             $optgroup->append_single_option_line('use_volumetric_e');
+            $optgroup->append_single_option_line('use_velocity_extrusion');
             $optgroup->append_single_option_line('pressure_advance');
             $optgroup->append_single_option_line('vibration_limit');
         }

--- a/utils/wireframe.pl
+++ b/utils/wireframe.pl
@@ -131,7 +131,7 @@ my %opt = (
                 
                     # extrude segments
                     foreach my $point (@points) {
-                        print $fh $gcodegen->writer->extrude_to_xyz($point, $e * $gcodegen->writer->get_position->distance_to($point));
+                        print $fh $gcodegen->writer->extrude_to_xyz($point, $e, $gcodegen->writer->get_position->distance_to($point));
                     }
                 }
             }
@@ -144,7 +144,7 @@ my %opt = (
                 
                 foreach my $line (@{$polyline->lines}) {
                     my $point = Slic3r::Pointf->new_unscale(@{ $line->b });
-                    print $fh $gcodegen->writer->extrude_to_xy($point, $e * unscale($line->length));
+                    print $fh $gcodegen->writer->extrude_to_xy($point, $e, unscale($line->length));
                 }
             }
         }

--- a/xs/src/libslic3r/ExtrusionEntity.cpp
+++ b/xs/src/libslic3r/ExtrusionEntity.cpp
@@ -114,7 +114,7 @@ REGISTER_CLASS(ExtrusionPath, "ExtrusionPath");
 #endif
 
 std::string
-ExtrusionPath::gcode(Extruder* extruder, double mm3_per_mm,
+ExtrusionPath::gcode(GCodeWriter *writer,  double mm3_per_mm,
     double F, double xofs, double yofs, std::string extrusion_axis,
     std::string gcode_line_suffix) const
 {
@@ -124,6 +124,7 @@ ExtrusionPath::gcode(Extruder* extruder, double mm3_per_mm,
     stream.setf(std::ios::fixed);
 
     double local_F = F;
+    Extruder *extruder = writer->extruder();
 
     Lines lines = this->polyline.lines();
     for (Lines::const_iterator line_it = lines.begin();

--- a/xs/src/libslic3r/ExtrusionEntity.cpp
+++ b/xs/src/libslic3r/ExtrusionEntity.cpp
@@ -114,8 +114,8 @@ REGISTER_CLASS(ExtrusionPath, "ExtrusionPath");
 #endif
 
 std::string
-ExtrusionPath::gcode(Extruder* extruder, double e, double F,
-    double xofs, double yofs, std::string extrusion_axis,
+ExtrusionPath::gcode(Extruder* extruder, double mm3_per_mm,
+    double F, double xofs, double yofs, std::string extrusion_axis,
     std::string gcode_line_suffix) const
 {
     dSP;
@@ -132,6 +132,7 @@ ExtrusionPath::gcode(Extruder* extruder, double e, double F,
         const double line_length = line_it->length() * SCALING_FACTOR;
 
         // calculate extrusion length for this line
+        double e = extruder->e_per_mm(mm3_per_mm);
         double E = 0;
         if (e > 0) {
             extruder->extrude(e * line_length);

--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -71,7 +71,7 @@ class ExtrusionPath : public ExtrusionEntity
     bool is_infill() const;
     bool is_solid_infill() const;
     bool is_bridge() const;
-    std::string gcode(Extruder* extruder, double e, double F,
+    std::string gcode(Extruder* extruder, double mm3_per_mm, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix) const;
     Polygons grow() const;

--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -4,12 +4,13 @@
 #include <myinit.h>
 #include "Polygon.hpp"
 #include "Polyline.hpp"
+#include "GCodeWriter.hpp"
 
 namespace Slic3r {
 
 class ExPolygonCollection;
 class ExtrusionEntityCollection;
-class Extruder;
+class GCodeWriter;
 
 /* Each ExtrusionRole value identifies a distinct set of { extruder, speed } */
 enum ExtrusionRole {
@@ -71,7 +72,7 @@ class ExtrusionPath : public ExtrusionEntity
     bool is_infill() const;
     bool is_solid_infill() const;
     bool is_bridge() const;
-    std::string gcode(Extruder* extruder, double mm3_per_mm, double F,
+    std::string gcode(GCodeWriter *writer, double mm3_per_mm, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix) const;
     Polygons grow() const;

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -10,6 +10,7 @@
 #define PRECISION(val, precision) std::fixed << std::setprecision(precision) << val
 #define XYZF_NUM(val) PRECISION(val, 3)
 #define E_NUM(val) PRECISION(val, 5)
+#define CROSS_NUM(val) PRECISION(val, 6)
 
 namespace Slic3r {
 
@@ -205,7 +206,9 @@ GCodeWriter::reset_e(bool force)
         this->_extruder->E = 0;
     }
     
-    if (!this->_extrusion_axis.empty() && !this->config.use_relative_e_distances) {
+    if (!this->_extrusion_axis.empty() &&
+        !this->config.use_relative_e_distances &&
+        !this->config.use_velocity_extrusion) {
         std::ostringstream gcode;
         gcode << "G92 " << this->_extrusion_axis << "0";
         if (this->config.gcode_comments) gcode << " ; reset extrusion distance";
@@ -277,6 +280,16 @@ GCodeWriter::set_speed(double F, const std::string &comment)
 {
     std::ostringstream gcode;
     gcode << "G1 F" << XYZF_NUM(F);
+    COMMENT(comment);
+    gcode << "\n";
+    return gcode.str();
+}
+
+std::string
+GCodeWriter::set_cross_section(double mm2, const std::string &comment)
+{
+    std::ostringstream gcode;
+    gcode << "M600 P" << CROSS_NUM(mm2);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -35,6 +35,7 @@ class GCodeWriter {
     std::string set_extruder(unsigned int extruder_id);
     std::string toolchange(unsigned int extruder_id);
     std::string set_speed(double F, const std::string &comment = std::string());
+    std::string set_cross_section(double mm2, const std::string &comment = std::string());
     std::string travel_to_xy(const Pointf &point, const std::string &comment = std::string());
     std::string travel_to_xyz(const Pointf3 &point, const std::string &comment = std::string());
     std::string travel_to_z(double z, const std::string &comment = std::string());

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -39,8 +39,8 @@ class GCodeWriter {
     std::string travel_to_xyz(const Pointf3 &point, const std::string &comment = std::string());
     std::string travel_to_z(double z, const std::string &comment = std::string());
     bool will_move_z(double z) const;
-    std::string extrude_to_xy(const Pointf &point, double dE, const std::string &comment = std::string());
-    std::string extrude_to_xyz(const Pointf3 &point, double dE, const std::string &comment = std::string());
+    std::string extrude_to_xy(const Pointf &point, double mm3_per_mm, double line_length, double F = 0, const std::string &comment = std::string());
+    std::string extrude_to_xyz(const Pointf3 &point, double mm3_per_mm, double line_length, double F = 0, const std::string &comment = std::string());
     std::string retract();
     std::string retract_for_toolchange();
     std::string unretract();

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -981,6 +981,11 @@ PrintConfigDef::build_def() {
     Options["use_volumetric_e"].tooltip = "This experimental setting uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.";
     Options["use_volumetric_e"].cli = "use-volumetric-e!";
 
+    Options["use_velocity_extrusion"].type = coBool;
+    Options["use_velocity_extrusion"].label = "Use velocity extrusion";
+    Options["use_velocity_extrusion"].tooltip = "This experimental setting uses additional M600 commands to set the cross area of a printed line. Instead of generating the movement of the extruder per extruder axis, the movement of the extruder is calculated by the firmware based on the velocity of the printing nozzle. This option does only work in combination with firmware retraction.";
+    Options["use_velocity_extrusion"].cli = "use-velocity-extrusion!";
+
     Options["vibration_limit"].type = coFloat;
     Options["vibration_limit"].label = "Vibration limit (deprecated)";
     Options["vibration_limit"].tooltip = "This experimental option will slow down those moves hitting the configured frequency limit. The purpose of limiting vibrations is to avoid mechanical resonance. Set zero to disable.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -319,6 +319,7 @@ class GCodeConfig : public virtual StaticPrintConfig
     ConfigOptionBool                use_firmware_retraction;
     ConfigOptionBool                use_relative_e_distances;
     ConfigOptionBool                use_volumetric_e;
+    ConfigOptionBool                use_velocity_extrusion;
     
     GCodeConfig() : StaticPrintConfig() {
         this->before_layer_gcode.value                           = "";
@@ -350,6 +351,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         this->use_firmware_retraction.value                      = false;
         this->use_relative_e_distances.value                     = false;
         this->use_volumetric_e.value                             = false;
+        this->use_velocity_extrusion.value                       = false;
     };
     
     ConfigOption* option(const t_config_option_key opt_key, bool create = false) {
@@ -374,6 +376,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         if (opt_key == "use_firmware_retraction")                    return &this->use_firmware_retraction;
         if (opt_key == "use_relative_e_distances")                   return &this->use_relative_e_distances;
         if (opt_key == "use_volumetric_e")                           return &this->use_volumetric_e;
+        if (opt_key == "use_velocity_extrusion")                     return &this->use_velocity_extrusion;
         
         return NULL;
     };

--- a/xs/xsp/ExtrusionPath.xsp
+++ b/xs/xsp/ExtrusionPath.xsp
@@ -26,7 +26,7 @@
     bool is_infill();
     bool is_solid_infill();
     bool is_bridge();
-    std::string gcode(Extruder* extruder, double mm3_per_mm, double F,
+    std::string gcode(GCodeWriter* writer, double mm3_per_mm, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix);
     Polygons grow();

--- a/xs/xsp/ExtrusionPath.xsp
+++ b/xs/xsp/ExtrusionPath.xsp
@@ -26,7 +26,7 @@
     bool is_infill();
     bool is_solid_infill();
     bool is_bridge();
-    std::string gcode(Extruder* extruder, double e, double F,
+    std::string gcode(Extruder* extruder, double mm3_per_mm, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix);
     Polygons grow();

--- a/xs/xsp/GCodeWriter.xsp
+++ b/xs/xsp/GCodeWriter.xsp
@@ -30,6 +30,7 @@
     std::string set_extruder(unsigned int extruder_id);
     std::string toolchange(unsigned int extruder_id);
     std::string set_speed(double F, std::string comment = std::string());
+    std::string set_cross_section(double mm2, std::string comment = std::string());
     std::string travel_to_xy(Pointf* point, std::string comment = std::string())
         %code{% RETVAL = THIS->travel_to_xy(*point, comment); %};
     std::string travel_to_xyz(Pointf3* point, std::string comment = std::string())

--- a/xs/xsp/GCodeWriter.xsp
+++ b/xs/xsp/GCodeWriter.xsp
@@ -36,10 +36,13 @@
         %code{% RETVAL = THIS->travel_to_xyz(*point, comment); %};
     std::string travel_to_z(double z, std::string comment = std::string());
     bool will_move_z(double z);
-    std::string extrude_to_xy(Pointf* point, double dE, std::string comment = std::string())
-        %code{% RETVAL = THIS->extrude_to_xy(*point, dE, comment); %};
-    std::string extrude_to_xyz(Pointf3* point, double dE, std::string comment = std::string())
-        %code{% RETVAL = THIS->extrude_to_xyz(*point, dE, comment); %};
+    std::string extrude_to_xy(Pointf* point, double mm3_per_mm, double
+    line_length, double F, std::string comment = std::string())
+        %code{% RETVAL = THIS->extrude_to_xy(*point, mm3_per_mm, line_length,
+    F, comment); %};
+    std::string extrude_to_xyz(Pointf3* point, double mm3_per_mm, double
+    line_length, double F = 0, std::string comment = std::string())
+        %code{% RETVAL = THIS->extrude_to_xyz(*point, mm3_per_mm, line_length, F, comment); %};
     std::string retract();
     std::string retract_for_toolchange();
     std::string unretract();


### PR DESCRIPTION
This patch adds support for velocity extrusion to Slic3r. Velocity extrusion means that the extrusion rate of the extruder is purely controlled based on the movement of the extrusion nozzle and a specified line cross section. This removes the additional extruder axis if velocity extrusion is enabled. The advantage of this method is the trajectory planner is able to optimze the movement easier. Furthermore this should increase the resulting printing precision (no rounding in the extruder axis movement).

For this purpose this patch adds an additional configuration option `use-velocity-extrusion`. In this mode no extruder output is generated, but an additional M600 command is added when the line cross section changes. This mode is only supported in combination with firmware retraction. At the moment the only firmware that supports velocity extrusion is Machinekit.

In order to do my modifactions I needed to move the command that outputs G1 movements to the GCodeWriter as it should be. So this patch implements following changes:

- moving GCode output from ExtrusionEntity to GCodeWriter
- calculate extruder movement in GCodeWriter instead of in GCode.pm -> cross section (mm3_per_mm) and line_length is used as parameters
- added additional config option `use-velocity-extrusion`
- added the config option to the UI
- added `set_cross_section` function to GCodeWriter
- using the `set_cross_section` function in GCode.pm
- small corrections in the documentation