### PR TITLE
Adding velocity extrusion support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ perl:
   - "5.14"
   - "5.18"
   - "5.20"
+  - "5.22"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ perl:
   - "5.14"
   - "5.18"
   - "5.20"
-  - "5.22"
 branches:
   only:
     - master

--- a/Build.PL
+++ b/Build.PL
@@ -118,7 +118,11 @@ EOF
     foreach my $module (sort keys %modules) {
         my $version = $modules{$module};
         my @cmd = ($cpanm, @cpanm_args);
-        push @cmd, '--notest', if $module eq 'OpenGL';  # temporary workaround for upstream bug in test
+        
+        # temporary workaround for upstream bug in test
+        push @cmd, '--notest'
+            if $module =~ /^(?:OpenGL|Math::PlanePath|Test::Harness)$/;
+        
         push @cmd, "$module~$version";
         if ($module eq 'XML::SAX::ExpatXS' && $^O eq 'MSWin32') {
             my $mingw = 'C:\dev\CitrusPerl\mingw64';

--- a/Build.PL
+++ b/Build.PL
@@ -23,7 +23,6 @@ my %prereqs = qw(
     Thread::Semaphore               0
     IO::Scalar                      0
     threads                         1.96
-    Time::HiRes                     0
     Unicode::Normalize              0
 );
 my %recommends = qw(

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The author of the Silk icon set is Mark James.
         --use-relative-e-distances Enable this to get relative E values (default: no)
         --use-firmware-retraction  Enable firmware-controlled retraction using G10/G11 (default: no)
         --use-volumetric-e  Express E in cubic millimeters and prepend M200 (default: no)
+        --use-velocity-extrusion Express E in velocity mode using the M700 command (default: no)
         --gcode-arcs        Use G2/G3 commands for native arcs (experimental, not supported
                             by all firmwares)
         --gcode-comments    Make G-code verbose by adding comments (default: no)

--- a/lib/Slic3r.pm
+++ b/lib/Slic3r.pm
@@ -30,7 +30,7 @@ warn "Running Slic3r under Perl 5.16 is not supported nor recommended\n"
     if $^V == v5.16;
 
 use FindBin;
-our $var = decode_path($FindBin::Bin) . "/var";
+our $var = decode_path($FindBin::Bin) . "/../res";
 
 use Moo 1.003001;
 

--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -247,6 +247,13 @@ sub validate {
     
     die "--use-firmware-retraction is not compatible with --wipe\n"
         if $self->use_firmware_retraction && first {$_} @{$self->wipe};
+
+    # --use-velocity-extrusion
+    die "--use-velocity-extrusion is only supported by Machinekit firmware\n"
+        if $self->use_velocity_extrusion && $self->gcode_flavor ne 'machinekit';
+
+    die "--use-velocity-extrusion must be used in combination with --use-firmware-retraction\n"
+        if $self->use_velocity_extrusion && !$self->use_firmware_retraction;
     
     # --fill-pattern
     die "Invalid value for --fill-pattern\n"

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -230,8 +230,12 @@ sub extrude_loop {
         my $point = $first_segment->point_at($distance);
         $point->rotate($angle, $first_segment->a);
         
-        # generate the travel move
-        $gcode .= $self->writer->travel_to_xy($self->point_to_gcode($point), "move inwards before travel");
+        # generate the travel move, usually unretracted -> also set cross section
+        my $comment = "move inwards before travel";
+        if ($self->config->use_velocity_extrusion) {
+            $gcode .= $self->writer->set_cross_section(0.0, $comment);
+        }
+        $gcode .= $self->writer->travel_to_xy($self->point_to_gcode($point), $comment);
     }
     
     return $gcode;

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -989,7 +989,7 @@ sub build {
         gcode_flavor use_relative_e_distances
         octoprint_host octoprint_apikey
         use_firmware_retraction pressure_advance vibration_limit
-        use_volumetric_e
+        use_volumetric_e use_velocity_extrusion
         start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode
         nozzle_diameter extruder_offset
         retract_length retract_lift retract_speed retract_restart_extra retract_before_travel retract_layer_change wipe
@@ -1132,6 +1132,7 @@ sub build {
             $optgroup->append_single_option_line('use_relative_e_distances');
             $optgroup->append_single_option_line('use_firmware_retraction');
             $optgroup->append_single_option_line('use_volumetric_e');
+            $optgroup->append_single_option_line('use_velocity_extrusion');
             $optgroup->append_single_option_line('pressure_advance');
             $optgroup->append_single_option_line('vibration_limit');
         }

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -10,6 +10,7 @@
 #define PRECISION(val, precision) std::fixed << std::setprecision(precision) << val
 #define XYZF_NUM(val) PRECISION(val, 3)
 #define E_NUM(val) PRECISION(val, 5)
+#define CROSS_NUM(val) PRECISION(val, 6)
 
 namespace Slic3r {
 
@@ -205,7 +206,9 @@ GCodeWriter::reset_e(bool force)
         this->_extruder->E = 0;
     }
     
-    if (!this->_extrusion_axis.empty() && !this->config.use_relative_e_distances) {
+    if (!this->_extrusion_axis.empty() &&
+        !this->config.use_relative_e_distances &&
+        !this->config.use_velocity_extrusion) {
         std::ostringstream gcode;
         gcode << "G92 " << this->_extrusion_axis << "0";
         if (this->config.gcode_comments) gcode << " ; reset extrusion distance";
@@ -277,6 +280,16 @@ GCodeWriter::set_speed(double F, const std::string &comment)
 {
     std::ostringstream gcode;
     gcode << "G1 F" << F;
+    COMMENT(comment);
+    gcode << "\n";
+    return gcode.str();
+}
+
+std::string
+GCodeWriter::set_cross_section(double mm2, const std::string &comment)
+{
+    std::ostringstream gcode;
+    gcode << "M700 P" << CROSS_NUM(mm2);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -35,6 +35,7 @@ class GCodeWriter {
     std::string set_extruder(unsigned int extruder_id);
     std::string toolchange(unsigned int extruder_id);
     std::string set_speed(double F, const std::string &comment = std::string());
+    std::string set_cross_section(double mm2, const std::string &comment = std::string());
     std::string travel_to_xy(const Pointf &point, const std::string &comment = std::string());
     std::string travel_to_xyz(const Pointf3 &point, const std::string &comment = std::string());
     std::string travel_to_z(double z, const std::string &comment = std::string());

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1009,6 +1009,11 @@ PrintConfigDef::build_def() {
     Options["use_volumetric_e"].tooltip = "This experimental setting uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.";
     Options["use_volumetric_e"].cli = "use-volumetric-e!";
 
+    Options["use_velocity_extrusion"].type = coBool;
+    Options["use_velocity_extrusion"].label = "Use velocity extrusion";
+    Options["use_velocity_extrusion"].tooltip = "This experimental setting uses additional M600 commands to set the cross area of a printed line. Instead of generating the movement of the extruder per extruder axis, the movement of the extruder is calculated by the firmware based on the velocity of the printing nozzle. This option does only work in combination with firmware retraction.";
+    Options["use_velocity_extrusion"].cli = "use-velocity-extrusion!";
+
     Options["vibration_limit"].type = coFloat;
     Options["vibration_limit"].label = "Vibration limit (deprecated)";
     Options["vibration_limit"].tooltip = "This experimental option will slow down those moves hitting the configured frequency limit. The purpose of limiting vibrations is to avoid mechanical resonance. Set zero to disable.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -321,6 +321,7 @@ class GCodeConfig : public virtual StaticPrintConfig
     ConfigOptionBool                use_firmware_retraction;
     ConfigOptionBool                use_relative_e_distances;
     ConfigOptionBool                use_volumetric_e;
+    ConfigOptionBool                use_velocity_extrusion;
     
     GCodeConfig() : StaticPrintConfig() {
         this->before_layer_gcode.value                           = "";
@@ -354,6 +355,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         this->use_firmware_retraction.value                      = false;
         this->use_relative_e_distances.value                     = false;
         this->use_volumetric_e.value                             = false;
+        this->use_velocity_extrusion.value                       = false;
     };
     
     ConfigOption* option(const t_config_option_key opt_key, bool create = false) {
@@ -380,6 +382,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         if (opt_key == "use_firmware_retraction")                    return &this->use_firmware_retraction;
         if (opt_key == "use_relative_e_distances")                   return &this->use_relative_e_distances;
         if (opt_key == "use_volumetric_e")                           return &this->use_volumetric_e;
+        if (opt_key == "use_velocity_extrusion")                     return &this->use_velocity_extrusion;
         
         return NULL;
     };

--- a/xs/xsp/GCodeWriter.xsp
+++ b/xs/xsp/GCodeWriter.xsp
@@ -30,6 +30,7 @@
     std::string set_extruder(unsigned int extruder_id);
     std::string toolchange(unsigned int extruder_id);
     std::string set_speed(double F, std::string comment = std::string());
+    std::string set_cross_section(double mm2, std::string comment = std::string());
     std::string travel_to_xy(Pointf* point, std::string comment = std::string())
         %code{% RETVAL = THIS->travel_to_xy(*point, comment); %};
     std::string travel_to_xyz(Pointf3* point, std::string comment = std::string())


### PR DESCRIPTION
This patch adds support for velocity extrusion to Slic3r. Velocity extrusion means that the extrusion rate of the extruder is purely controlled based on the movement of the extrusion nozzle and a specified line cross section. This removes the additional extruder axis if velocity extrusion is enabled. The advantage of this method is the trajectory planner is able to optimze the movement easier. Furthermore this should increase the resulting printing precision (no rounding in the extruder axis movement).

For this purpose this patch adds an additional configuration option use-velocity-extrusion. In this mode no extruder output is generated, but an additional M700 command is added when the line cross section changes. This mode is only supported in combination with firmware retraction. At the moment the only firmware that supports velocity extrusion is Machinekit.

This patch implements following changes:
- added additional config option use-velocity-extrusion
- added the config option to the UI
- added set_cross_section function to GCodeWriter
- using the set_cross_section function in GCode.pm

This PR replaces https://github.com/alexrj/Slic3r/pull/2716
