### PR TITLE
Moving GCode output from ExtrusionEntity to GCodeWriter

### DIFF
--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -309,7 +309,7 @@ sub _extrude_path {
     my $path_length = unscale $path->length;
     {
         my $extruder_offset = $self->config->get_at('extruder_offset', $self->writer->extruder->id);
-        $gcode .= $path->gcode($self->writer->extruder, $e_per_mm, $F,
+        $gcode .= $path->gcode($self->writer, $e_per_mm, $F,
             $self->origin->x - $extruder_offset->x,
             $self->origin->y - $extruder_offset->y,  #-
             $self->writer->extrusion_axis,

--- a/lib/Slic3r/GCode.pm
+++ b/lib/Slic3r/GCode.pm
@@ -579,14 +579,16 @@ sub wipe {
             my $segment_length = $line->length;
             # Reduce retraction length a bit to avoid effective retraction speed to be greater than the configured one
             # due to rounding (TODO: test and/or better math for this)
-            my $dE = $length * ($segment_length / $wipe_dist) * 0.95;
+            my $mm3_per_mm = ($segment_length / $wipe_dist) * 0.95;
             $gcode .= $gcodegen->writer->set_speed($wipe_speed*60);
             $gcode .= $gcodegen->writer->extrude_to_xy(
                 $gcodegen->point_to_gcode($line->b),
-                -$dE,
+                $mm3_per_mm,
+                -$length,
+                $wipe_speed*60,
                 'wipe and retract' . ($gcodegen->enable_cooling_markers ? ';_WIPE' : ''),
             );
-            $retracted += $dE;
+            $retracted += $length * $mm3_per_mm;
         }
         $gcodegen->writer->extruder->set_retracted($gcodegen->writer->extruder->retracted + $retracted);
         

--- a/utils/wireframe.pl
+++ b/utils/wireframe.pl
@@ -131,7 +131,7 @@ my %opt = (
                 
                     # extrude segments
                     foreach my $point (@points) {
-                        print $fh $gcodegen->writer->extrude_to_xyz($point, $e * $gcodegen->writer->get_position->distance_to($point));
+                        print $fh $gcodegen->writer->extrude_to_xyz($point, $e, $gcodegen->writer->get_position->distance_to($point));
                     }
                 }
             }
@@ -144,7 +144,7 @@ my %opt = (
                 
                 foreach my $line (@{$polyline->lines}) {
                     my $point = Slic3r::Pointf->new_unscale(@{ $line->b });
-                    print $fh $gcodegen->writer->extrude_to_xy($point, $e * unscale($line->length));
+                    print $fh $gcodegen->writer->extrude_to_xy($point, $e, unscale($line->length));
                 }
             }
         }

--- a/xs/src/libslic3r/ExtrusionEntity.cpp
+++ b/xs/src/libslic3r/ExtrusionEntity.cpp
@@ -121,10 +121,7 @@ ExtrusionPath::gcode(GCodeWriter *writer,  double e, double F,
     dSP;
 
     std::stringstream stream;
-    stream.setf(std::ios::fixed);
-
     double local_F = F;
-    Extruder *extruder = writer->extruder();
 
     Lines lines = this->polyline.lines();
     for (Lines::const_iterator line_it = lines.begin();
@@ -132,34 +129,19 @@ ExtrusionPath::gcode(GCodeWriter *writer,  double e, double F,
     {
         const double line_length = line_it->length() * SCALING_FACTOR;
 
-        // calculate extrusion length for this line
-        double E = 0;
-        if (e > 0) {
-            extruder->extrude(e * line_length);
-            E = extruder->E;
-        }
-
         // compose G-code line
-
         Point point = line_it->b;
-        const double x = point.x * SCALING_FACTOR + xofs;
-        const double y = point.y * SCALING_FACTOR + yofs;
-        stream.precision(3);
-        stream << "G1 X" << x << " Y" << y;
+        Pointf pointf;
+        pointf.x = point.x * SCALING_FACTOR + xofs;
+        pointf.y = point.y * SCALING_FACTOR + yofs;
 
-        if (E != 0) {
-            stream.precision(5);
-            stream << " " << extrusion_axis << E;
-        }
-
-        if (local_F != 0) {
-            stream.precision(3);
-            stream << " F" << local_F;
-            local_F = 0;
-        }
-
-        stream << gcode_line_suffix;
-        stream << "\n";
+        stream << writer->extrude_to_xy(pointf,
+                                        e,
+                                        line_length,
+                                        local_F,
+                                        gcode_line_suffix);
+        // only use F of first move
+        local_F = 0;
     }
 
     return stream.str();

--- a/xs/src/libslic3r/ExtrusionEntity.cpp
+++ b/xs/src/libslic3r/ExtrusionEntity.cpp
@@ -114,7 +114,7 @@ REGISTER_CLASS(ExtrusionPath, "ExtrusionPath");
 #endif
 
 std::string
-ExtrusionPath::gcode(Extruder* extruder, double e, double F,
+ExtrusionPath::gcode(GCodeWriter *writer,  double e, double F,
     double xofs, double yofs, std::string extrusion_axis,
     std::string gcode_line_suffix) const
 {
@@ -124,6 +124,7 @@ ExtrusionPath::gcode(Extruder* extruder, double e, double F,
     stream.setf(std::ios::fixed);
 
     double local_F = F;
+    Extruder *extruder = writer->extruder();
 
     Lines lines = this->polyline.lines();
     for (Lines::const_iterator line_it = lines.begin();

--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -4,12 +4,13 @@
 #include <myinit.h>
 #include "Polygon.hpp"
 #include "Polyline.hpp"
+#include "GCodeWriter.hpp"
 
 namespace Slic3r {
 
 class ExPolygonCollection;
 class ExtrusionEntityCollection;
-class Extruder;
+class GCodeWriter;
 
 /* Each ExtrusionRole value identifies a distinct set of { extruder, speed } */
 enum ExtrusionRole {
@@ -74,7 +75,7 @@ class ExtrusionPath : public ExtrusionEntity
     bool is_infill() const;
     bool is_solid_infill() const;
     bool is_bridge() const;
-    std::string gcode(Extruder* extruder, double e, double F,
+    std::string gcode(GCodeWriter *writer, double e, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix) const;
     Polygons grow() const;

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -276,7 +276,7 @@ std::string
 GCodeWriter::set_speed(double F, const std::string &comment)
 {
     std::ostringstream gcode;
-    gcode << "G1 F" << F;
+    gcode << "G1 F" << XYZF_NUM(F);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();
@@ -370,33 +370,50 @@ GCodeWriter::will_move_z(double z) const
 }
 
 std::string
-GCodeWriter::extrude_to_xy(const Pointf &point, double dE, const std::string &comment)
+GCodeWriter::extrude_to_xy(const Pointf &point, double e, double line_length, double F, const std::string &comment)
 {
     this->_pos.x = point.x;
     this->_pos.y = point.y;
-    this->_extruder->extrude(dE);
-    
+
     std::ostringstream gcode;
     gcode << "G1 X" << XYZF_NUM(point.x)
-          <<   " Y" << XYZF_NUM(point.y)
-          <<    " " << this->_extrusion_axis << E_NUM(this->_extruder->E);
+          <<   " Y" << XYZF_NUM(point.y);
+
+    // calculate extrusion length for this line
+    if (e > 0) {
+        this->_extruder->extrude(e * line_length);
+        gcode << " " << this->_extrusion_axis << E_NUM(this->_extruder->E);
+    }
+
+    if (F > 0) {
+        gcode << " F" << XYZF_NUM(F);
+    }
+
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();
 }
 
 std::string
-GCodeWriter::extrude_to_xyz(const Pointf3 &point, double dE, const std::string &comment)
+GCodeWriter::extrude_to_xyz(const Pointf3 &point, double e, double line_length, double F, const std::string &comment)
 {
     this->_pos = point;
     this->_lifted = 0;
-    this->_extruder->extrude(dE);
-    
+
     std::ostringstream gcode;
     gcode << "G1 X" << XYZF_NUM(point.x)
           <<   " Y" << XYZF_NUM(point.y)
-          <<   " Z" << XYZF_NUM(point.z)
-          <<    " " << this->_extrusion_axis << E_NUM(this->_extruder->E);
+          <<   " Z" << XYZF_NUM(point.z);
+
+    if (e > 0) {
+        this->_extruder->extrude(e * line_length);
+        gcode << " " << this->_extrusion_axis << E_NUM(this->_extruder->E);
+    }
+
+    if (F > 0) {
+        gcode << " F" << XYZF_NUM(F);
+    }
+
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -39,8 +39,8 @@ class GCodeWriter {
     std::string travel_to_xyz(const Pointf3 &point, const std::string &comment = std::string());
     std::string travel_to_z(double z, const std::string &comment = std::string());
     bool will_move_z(double z) const;
-    std::string extrude_to_xy(const Pointf &point, double dE, const std::string &comment = std::string());
-    std::string extrude_to_xyz(const Pointf3 &point, double dE, const std::string &comment = std::string());
+    std::string extrude_to_xy(const Pointf &point, double e, double line_length, double F = 0, const std::string &comment = std::string());
+    std::string extrude_to_xyz(const Pointf3 &point, double e, double line_length, double F = 0, const std::string &comment = std::string());
     std::string retract();
     std::string retract_for_toolchange();
     std::string unretract();

--- a/xs/xsp/ExtrusionPath.xsp
+++ b/xs/xsp/ExtrusionPath.xsp
@@ -26,7 +26,7 @@
     bool is_infill();
     bool is_solid_infill();
     bool is_bridge();
-    std::string gcode(Extruder* extruder, double e, double F,
+    std::string gcode(GCodeWriter* writer, double e, double F,
         double xofs, double yofs, std::string extrusion_axis,
         std::string gcode_line_suffix);
     Polygons grow();

--- a/xs/xsp/GCodeWriter.xsp
+++ b/xs/xsp/GCodeWriter.xsp
@@ -36,10 +36,13 @@
         %code{% RETVAL = THIS->travel_to_xyz(*point, comment); %};
     std::string travel_to_z(double z, std::string comment = std::string());
     bool will_move_z(double z);
-    std::string extrude_to_xy(Pointf* point, double dE, std::string comment = std::string())
-        %code{% RETVAL = THIS->extrude_to_xy(*point, dE, comment); %};
-    std::string extrude_to_xyz(Pointf3* point, double dE, std::string comment = std::string())
-        %code{% RETVAL = THIS->extrude_to_xyz(*point, dE, comment); %};
+    std::string extrude_to_xy(Pointf* point, double e, double
+    line_length, double F, std::string comment = std::string())
+        %code{% RETVAL = THIS->extrude_to_xy(*point, e, line_length,
+    F, comment); %};
+    std::string extrude_to_xyz(Pointf3* point, double e, double
+    line_length, double F = 0, std::string comment = std::string())
+        %code{% RETVAL = THIS->extrude_to_xyz(*point, e, line_length, F, comment); %};
     std::string retract();
     std::string retract_for_toolchange();
     std::string unretract();


### PR DESCRIPTION
For some reason extrusion GCode is output directly from ExtrusionEntity. This patch moves the output to GCodeWriter to make porting for different firmwares easier.