### PR TITLE
Support for standalone C++ library

### DIFF
--- a/xs/src/libslic3r/BridgeDetector.cpp
+++ b/xs/src/libslic3r/BridgeDetector.cpp
@@ -3,6 +3,10 @@
 #include "Geometry.hpp"
 #include <algorithm>
 
+#ifdef SLIC3R_DEBUG
+#include <stdio.h>
+#endif
+
 namespace Slic3r {
 
 class BridgeDirectionComparator {

--- a/xs/src/libslic3r/ClipperUtils.cpp
+++ b/xs/src/libslic3r/ClipperUtils.cpp
@@ -597,7 +597,7 @@ void union_pt_chained(const Slic3r::Polygons &subject, Slic3r::Polygons* retval,
     traverse_pt(pt.Childs, retval);
 }
 
-static void traverse_pt(ClipperLib::PolyNodes &nodes, Slic3r::Polygons* retval)
+void traverse_pt(ClipperLib::PolyNodes &nodes, Slic3r::Polygons* retval)
 {
     /* use a nearest neighbor search to order these children
        TODO: supply start_near to chained_path() too? */

--- a/xs/src/libslic3r/ClipperUtils.cpp
+++ b/xs/src/libslic3r/ClipperUtils.cpp
@@ -538,7 +538,7 @@ template <class SubjectType>
 bool intersects(const SubjectType &subject, const Slic3r::Polygons &clip, bool safety_offset_)
 {
     SubjectType retval;
-    intersection(subject, clip, &retval, safety_offset_);
+    intersection(subject, clip, &retval, safety_offset_, true); //eraseOutput=true for default semantics here
     return !retval.empty();
 }
 template bool intersects<Slic3r::Polygons>(const Slic3r::Polygons &subject, const Slic3r::Polygons &clip, bool safety_offset_);

--- a/xs/src/libslic3r/ClipperUtils.cpp
+++ b/xs/src/libslic3r/ClipperUtils.cpp
@@ -92,12 +92,14 @@ Slic3rMultiPoints_to_ClipperPaths(const T &input, ClipperLib::Paths* output)
 void
 scaleClipperPolygons(ClipperLib::Paths &polygons, const double scale)
 {
+  if (scale!=1.0) {
     for (ClipperLib::Paths::iterator it = polygons.begin(); it != polygons.end(); ++it) {
         for (ClipperLib::Path::iterator pit = (*it).begin(); pit != (*it).end(); ++pit) {
             (*pit).X *= scale;
             (*pit).Y *= scale;
         }
     }
+  }
 }
 
 void

--- a/xs/src/libslic3r/ClipperUtils.hpp
+++ b/xs/src/libslic3r/ClipperUtils.hpp
@@ -129,7 +129,7 @@ void union_(const Slic3r::Polygons &subject1, const Slic3r::Polygons &subject2, 
 
 void union_pt(const Slic3r::Polygons &subject, ClipperLib::PolyTree* retval, bool safety_offset_ = false);
 void union_pt_chained(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool safety_offset_ = false);
-static void traverse_pt(ClipperLib::PolyNodes &nodes, Slic3r::Polygons* retval);
+void traverse_pt(ClipperLib::PolyNodes &nodes, Slic3r::Polygons* retval);
 
 void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool preserve_collinear = false);
 void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::ExPolygons* retval, bool preserve_collinear = false);

--- a/xs/src/libslic3r/ClipperUtils.hpp
+++ b/xs/src/libslic3r/ClipperUtils.hpp
@@ -27,6 +27,8 @@ template <class T>
 void Slic3rMultiPoints_to_ClipperPaths(const T &input, ClipperLib::Paths* output);
 template <class T>
 void ClipperPath_to_Slic3rMultiPoint(const ClipperLib::Path &input, T* output, bool eraseOutput = true);
+void Add_Slic3rExPolygon_to_ClipperPaths(const Slic3r::ExPolygon &input, ClipperLib::Paths* output);
+void Slic3rExPolygons_to_ClipperPaths(const Slic3r::ExPolygons &input, ClipperLib::Paths* output);
 template <class T>
 void ClipperPaths_to_Slic3rMultiPoints(const ClipperLib::Paths &input, T* output, bool eraseOutput = true);
 void ClipperPaths_to_Slic3rExPolygons(const ClipperLib::Paths &input, Slic3r::ExPolygons* output, bool eraseOutput = true);
@@ -62,6 +64,9 @@ Slic3r::ExPolygons offset_ex(const Slic3r::Polygons &polygons, const float delta
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
 
+void offset2(const ClipperLib::Paths &paths, ClipperLib::Paths* retval, const float delta1,
+    const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
+    double miterLimit = 3);
 void offset2(const Slic3r::Polygons &polygons, ClipperLib::Paths* retval, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
@@ -77,7 +82,22 @@ void offset2(const Slic3r::Polygons &polygons, Slic3r::ExPolygons* retval, const
 Slic3r::ExPolygons offset2_ex(const Slic3r::Polygons &polygons, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
+void offset2(const Slic3r::ExPolygons &polygons, Slic3r::ExPolygons* retval, const float delta1,
+    const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
+    double miterLimit = 3, bool eraseOutput = true);
+void offset2(const Slic3r::ExPolygons &polygons, Slic3r::Polygons* retval, const float delta1,
+    const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
+    double miterLimit = 3, bool eraseOutput = true);
+void offset2(const Slic3r::ExPolygon &polygon, Slic3r::ExPolygons* retval, const float delta1,
+    const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
+    double miterLimit = 3, bool eraseOutput = true);
+void offset2(const Slic3r::ExPolygon &polygon, Slic3r::Polygons* retval, const float delta1,
+    const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
+    double miterLimit = 3, bool eraseOutput = true);
 
+template <class T>
+void _clipper_do(ClipperLib::ClipType clipType, const Slic3r::ExPolygons &subject, 
+    const Slic3r::Polygons &clip, T* retval, bool safety_offset_);
 template <class T>
 void _clipper_do(ClipperLib::ClipType clipType, const Slic3r::Polygons &subject, 
     const Slic3r::Polygons &clip, T* retval, bool safety_offset_);

--- a/xs/src/libslic3r/ClipperUtils.hpp
+++ b/xs/src/libslic3r/ClipperUtils.hpp
@@ -19,17 +19,17 @@ namespace Slic3r {
 //-----------------------------------------------------------
 // legacy code from Clipper documentation
 void AddOuterPolyNodeToExPolygons(ClipperLib::PolyNode& polynode, Slic3r::ExPolygons& expolygons);
-void PolyTreeToExPolygons(ClipperLib::PolyTree& polytree, Slic3r::ExPolygons& expolygons);
+void PolyTreeToExPolygons(ClipperLib::PolyTree& polytree, Slic3r::ExPolygons& expolygons, bool eraseOutput = true);
 //-----------------------------------------------------------
 
 void Slic3rMultiPoint_to_ClipperPath(const Slic3r::MultiPoint &input, ClipperLib::Path* output);
 template <class T>
 void Slic3rMultiPoints_to_ClipperPaths(const T &input, ClipperLib::Paths* output);
 template <class T>
-void ClipperPath_to_Slic3rMultiPoint(const ClipperLib::Path &input, T* output);
+void ClipperPath_to_Slic3rMultiPoint(const ClipperLib::Path &input, T* output, bool eraseOutput = true);
 template <class T>
-void ClipperPaths_to_Slic3rMultiPoints(const ClipperLib::Paths &input, T* output);
-void ClipperPaths_to_Slic3rExPolygons(const ClipperLib::Paths &input, Slic3r::ExPolygons* output);
+void ClipperPaths_to_Slic3rMultiPoints(const ClipperLib::Paths &input, T* output, bool eraseOutput = true);
+void ClipperPaths_to_Slic3rExPolygons(const ClipperLib::Paths &input, Slic3r::ExPolygons* output, bool eraseOutput = true);
 
 void scaleClipperPolygons(ClipperLib::Paths &polygons, const double scale);
 
@@ -39,7 +39,7 @@ void offset(const Slic3r::Polygons &polygons, ClipperLib::Paths* retval, const f
     double miterLimit = 3);
 void offset(const Slic3r::Polygons &polygons, Slic3r::Polygons* retval, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 Slic3r::Polygons offset(const Slic3r::Polygons &polygons, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
@@ -50,14 +50,14 @@ void offset(const Slic3r::Polylines &polylines, ClipperLib::Paths* retval, const
     double miterLimit = 3);
 void offset(const Slic3r::Polylines &polylines, Slic3r::Polygons* retval, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtSquare, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 void offset(const Slic3r::Surface &surface, Slic3r::Surfaces* retval, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtSquare, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 
 void offset(const Slic3r::Polygons &polygons, Slic3r::ExPolygons* retval, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 Slic3r::ExPolygons offset_ex(const Slic3r::Polygons &polygons, const float delta,
     double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
@@ -67,13 +67,13 @@ void offset2(const Slic3r::Polygons &polygons, ClipperLib::Paths* retval, const 
     double miterLimit = 3);
 void offset2(const Slic3r::Polygons &polygons, Slic3r::Polygons* retval, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 Slic3r::Polygons offset2(const Slic3r::Polygons &polygons, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
 void offset2(const Slic3r::Polygons &polygons, Slic3r::ExPolygons* retval, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
-    double miterLimit = 3);
+    double miterLimit = 3, bool eraseOutput = true);
 Slic3r::ExPolygons offset2_ex(const Slic3r::Polygons &polygons, const float delta1,
     const float delta2, double scale = 100000, ClipperLib::JoinType joinType = ClipperLib::jtMiter, 
     double miterLimit = 3);
@@ -84,19 +84,15 @@ void _clipper_do(ClipperLib::ClipType clipType, const Slic3r::Polygons &subject,
 void _clipper_do(ClipperLib::ClipType clipType, const Slic3r::Polylines &subject, 
     const Slic3r::Polygons &clip, ClipperLib::Paths* retval, bool safety_offset_);
 void _clipper(ClipperLib::ClipType clipType, const Slic3r::Polygons &subject, 
-    const Slic3r::Polygons &clip, Slic3r::Polygons* retval, bool safety_offset_);
+    const Slic3r::Polygons &clip, Slic3r::Polygons* retval, bool safety_offset_, bool eraseOutput = true);
 void _clipper(ClipperLib::ClipType clipType, const Slic3r::Polygons &subject, 
-    const Slic3r::Polygons &clip, Slic3r::ExPolygons* retval, bool safety_offset_);
-void _clipper(ClipperLib::ClipType clipType, const Slic3r::Polylines &subject, 
-    const Slic3r::Polygons &clip, Slic3r::Polylines* retval);
-void _clipper(ClipperLib::ClipType clipType, const Slic3r::Lines &subject, 
-    const Slic3r::Polygons &clip, Slic3r::Lines* retval);
+    const Slic3r::Polygons &clip, Slic3r::ExPolygons* retval, bool safety_offset_, bool eraseOutput = true);
 
 template <class SubjectType, class ResultType>
-void diff(const SubjectType &subject, const Slic3r::Polygons &clip, ResultType* retval, bool safety_offset_ = false);
+void diff(const SubjectType &subject, const Slic3r::Polygons &clip, ResultType* retval, bool safety_offset_ = false, bool eraseOutput = true);
 
 template <class SubjectType, class ResultType>
-void diff(const SubjectType &subject, const Slic3r::ExPolygons &clip, ResultType* retval, bool safety_offset_ = false);
+void diff(const SubjectType &subject, const Slic3r::ExPolygons &clip, ResultType* retval, bool safety_offset_ = false, bool eraseOutput = true);
 
 Slic3r::Polygons diff(const Slic3r::Polygons &subject, const Slic3r::Polygons &clip, bool safety_offset_ = false);
 
@@ -104,7 +100,7 @@ template <class SubjectType, class ClipType>
 Slic3r::ExPolygons diff_ex(const SubjectType &subject, const ClipType &clip, bool safety_offset_ = false);
 
 template <class SubjectType, class ResultType>
-void intersection(const SubjectType &subject, const Slic3r::Polygons &clip, ResultType* retval, bool safety_offset_ = false);
+void intersection(const SubjectType &subject, const Slic3r::Polygons &clip, ResultType* retval, bool safety_offset_ = false, bool eraseOutput = true);
 
 template <class SubjectType>
 SubjectType intersection(const SubjectType &subject, const Slic3r::Polygons &clip, bool safety_offset_ = false);
@@ -116,23 +112,23 @@ template <class SubjectType>
 bool intersects(const SubjectType &subject, const Slic3r::Polygons &clip, bool safety_offset_ = false);
 
 void xor_(const Slic3r::Polygons &subject, const Slic3r::Polygons &clip, Slic3r::ExPolygons* retval, 
-    bool safety_offset_ = false);
+    bool safety_offset_ = false, bool eraseOutput = true);
 
 template <class T>
-void union_(const Slic3r::Polygons &subject, T* retval, bool safety_offset_ = false);
+void union_(const Slic3r::Polygons &subject, T* retval, bool safety_offset_ = false, bool eraseOutput = true);
 
 Slic3r::Polygons union_(const Slic3r::Polygons &subject, bool safety_offset = false);
 Slic3r::ExPolygons union_ex(const Slic3r::Polygons &subject, bool safety_offset = false);
 Slic3r::ExPolygons union_ex(const Slic3r::Surfaces &subject, bool safety_offset = false);
 
-void union_(const Slic3r::Polygons &subject1, const Slic3r::Polygons &subject2, Slic3r::Polygons* retval, bool safety_offset = false);
+void union_(const Slic3r::Polygons &subject1, const Slic3r::Polygons &subject2, Slic3r::Polygons* retval, bool safety_offset = false, bool eraseOutput = true);
 
 void union_pt(const Slic3r::Polygons &subject, ClipperLib::PolyTree* retval, bool safety_offset_ = false);
-void union_pt_chained(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool safety_offset_ = false);
+void union_pt_chained(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool safety_offset_ = false, bool eraseOutput=true);
 void traverse_pt(ClipperLib::PolyNodes &nodes, Slic3r::Polygons* retval);
 
-void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool preserve_collinear = false);
-void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::ExPolygons* retval, bool preserve_collinear = false);
+void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::Polygons* retval, bool preserve_collinear = false, bool eraseOutput = true);
+void simplify_polygons(const Slic3r::Polygons &subject, Slic3r::ExPolygons* retval, bool preserve_collinear = false, bool eraseOutput = true);
 
 void safety_offset(ClipperLib::Paths* paths);
 

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -829,9 +829,8 @@ TriangleMeshSlicer::make_expolygons(const Polygons &loops, ExPolygons* slices)
     }
 
     // perform a safety offset to merge very close facets (TODO: find test case for this)
-    double safety_offset = scale_(0.0499);
     ExPolygons ex_slices;
-    offset2(p_slices, &ex_slices, +safety_offset, -safety_offset);
+    offset2(p_slices, &ex_slices, +this->safety_offset, -this->safety_offset);
     
     #ifdef SLIC3R_DEBUG
     size_t holes_count = 0;
@@ -1010,7 +1009,7 @@ TriangleMeshSlicer::cut(float z, TriangleMesh* upper, TriangleMesh* lower)
     
 }
 
-TriangleMeshSlicer::TriangleMeshSlicer(TriangleMesh* _mesh) : mesh(_mesh), v_scaled_shared(NULL)
+TriangleMeshSlicer::TriangleMeshSlicer(TriangleMesh* _mesh, double _safety_offset) : mesh(_mesh), safety_offset(_safety_offset), v_scaled_shared(NULL)
 {
     // build a table to map a facet_idx to its three edge indices
     this->mesh->require_shared_vertices();

--- a/xs/src/libslic3r/TriangleMesh.hpp
+++ b/xs/src/libslic3r/TriangleMesh.hpp
@@ -82,11 +82,14 @@ class IntersectionLine : public Line
 typedef std::vector<IntersectionLine> IntersectionLines;
 typedef std::vector<IntersectionLine*> IntersectionLinePtrs;
 
+#define DEFAULT_SLICING_SAFETY_OFFSET scale_(0.0499)
+
 class TriangleMeshSlicer
 {
     public:
     TriangleMesh* mesh;
-    TriangleMeshSlicer(TriangleMesh* _mesh);
+    double safety_offset;
+    TriangleMeshSlicer(TriangleMesh* _mesh, double _safety_offset=DEFAULT_SLICING_SAFETY_OFFSET);
     ~TriangleMeshSlicer();
     void slice(const std::vector<float> &z, std::vector<Polygons>* layers);
     void slice(const std::vector<float> &z, std::vector<ExPolygons>* layers);


### PR DESCRIPTION
This pull request contains some minor bug fixes to compile the core C++ sources as a standalone library, as well as some minor changes to make it more convenient as a library (mainly un-hardcoding values and behaviours). 

The last commit adds several overloaded versions of offset2() in ClipperUtils. I can merge all offset2() definitions into a single templated function, if it is better that way