### PR TITLE
Infill strategy for laser printing (SLS SLA)

### DIFF
--- a/lib/Slic3r.pm
+++ b/lib/Slic3r.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 require v5.10;
 
-our $VERSION = "0.9.10";
+our $VERSION = "0.9.10b";
 
 our $debug = 0;
 sub debugf {

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1097,6 +1097,7 @@ sub _trigger_model_object {
 	    $self->bounding_box($self->model_object->bounding_box);
 	    
     	my $mesh = $self->model_object->mesh;
+        $self->convex_hull(Slic3r::Polygon->new(Math::ConvexHull::MonotoneChain::convex_hull($mesh->used_vertices)));
 	    $self->facets(scalar @{$mesh->facets});
 	    $self->vertices(scalar @{$mesh->vertices});
 	    
@@ -1139,7 +1140,6 @@ sub make_thumbnail {
     my $self = shift;
     
     my $mesh = $self->model_object->mesh;  # $self->model_object is already aligned to origin
-    $self->convex_hull(Slic3r::Polygon->new(Math::ConvexHull::MonotoneChain::convex_hull($mesh->vertices)));
     my $thumbnail = Slic3r::ExPolygon::Collection->new(
     	expolygons => (@{$mesh->facets} <= 5000)
     		? $mesh->horizontal_projection


### PR DESCRIPTION
Should be important have the option to use a filling strategy for laser  Beam based printers like SLS or SLA, these printers dont have the  Ooze problems crossing perimeters but the action to leave the infill operation localy to start in another point and then come back it's letal for the correct power distribution of the ray on the surface.Best option a simply scansion that start from one direction to finish in the opposite direction.
Thankyou