### PR TITLE
To let Slic3r compile in Windows

### DIFF
--- a/xs/src/boost/test/utils/runtime/config.hpp
+++ b/xs/src/boost/test/utils/runtime/config.hpp
@@ -79,7 +79,7 @@ putenv_impl( cstring name, cstring value )
 {
     using namespace std;
     // !! this may actually fail. What should we do?
-    setenv( name.begin(), value.begin(), 1 );
+    _putenv_s( name.begin(), value.begin());
 }
 #else
 inline void


### PR DESCRIPTION
setenv isn't compatable in Windows but _putenv_s is.

How can I update all my files to your recent ones. I synced but the files I have are 8 months old for some reason.