### PR TITLE
GUI/Export GCode: fix file name extension and filters

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -41,7 +41,7 @@ use constant FILE_WILDCARDS => {
     obj     => 'OBJ files (*.obj)|*.obj;*.OBJ',
     amf     => 'AMF files (*.amf)|*.amf;*.AMF;*.xml;*.XML',
     ini     => 'INI files *.ini|*.ini;*.INI',
-    gcode   => 'G-code files (*.gcode, *.gco, *.g, *.ngc)|*.gcode;*.GCODE;*.gco;*.GCO;*.g;*.G;*.ngc;*.NGC',
+    gcode   => 'G-code files (*.gcode, *.gco, *.g)|*.gcode;*.GCODE;*.gco;*.GCO;*.g;*.G|rs274ngc files (*.ngc)|*.ngc;*.NGC|All files (*.*)|*.*',
     svg     => 'SVG files *.svg|*.svg;*.SVG',
 };
 use constant MODEL_WILDCARD => join '|', @{&FILE_WILDCARDS}{qw(known stl obj amf)};

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
-use File::Basename qw(basename dirname);
+use File::Basename qw(basename dirname fileparse);
 use List::Util qw(sum first max);
 use Slic3r::Geometry qw(X Y Z MIN MAX scale unscale deg2rad);
 use threads::shared qw(shared_clone);
@@ -1098,6 +1098,19 @@ sub export_gcode {
         my $default_output_file = $self->{print}->expanded_output_filepath($main::opt{output});
         my $dlg = Wx::FileDialog->new($self, 'Save G-code file as:', wxTheApp->output_path(dirname($default_output_file)),
             basename($default_output_file), &Slic3r::GUI::FILE_WILDCARDS->{gcode}, wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+        
+        # select correct filter
+        my ($filedir, $filename, $fileext) = fileparse($default_output_file, '\..*');
+        if (grep {$_ eq $fileext} ('.gcode', '.GCODE', '.gco', '.GCO.', '.g', '.G')) {
+            $dlg->SetFilterIndex(0);
+	}
+        elsif (grep {$_ eq $fileext} ('.ngc', '.NGC')) {
+            $dlg->SetFilterIndex(1);
+        }
+        else {
+            $dlg->SetFilterIndex(2);
+        }
+
         if ($dlg->ShowModal != wxID_OK) {
             $dlg->Destroy;
             return;


### PR DESCRIPTION
Fix for the following issue:
https://github.com/alexrj/Slic3r/issues/3025

Selects the correct filter in the export GCode dialog so the operating system does not overwrite the file extension.