### PR TITLE
Fix Slic3r crash when opening About dialog

### DIFF
--- a/lib/Slic3r/GUI/AboutDialog.pm
+++ b/lib/Slic3r/GUI/AboutDialog.pm
@@ -66,7 +66,7 @@ sub new {
     $vsizer->Add($html, 1, wxEXPAND | wxALIGN_LEFT | wxRIGHT | wxBOTTOM, 20);
     EVT_HTML_LINK_CLICKED($self, $html, \&link_clicked);
     
-    my $buttons = $self->CreateStdDialogButtonSizer(wxCLOSE);
+    my $buttons = $self->CreateStdDialogButtonSizer(wxOK);
     $self->SetEscapeId(wxID_CLOSE);
     EVT_BUTTON($self, wxID_CLOSE, sub {
         $self->EndModal(wxID_CLOSE);

--- a/lib/Slic3r/GUI/Projector.pm
+++ b/lib/Slic3r/GUI/Projector.pm
@@ -375,7 +375,7 @@ sub new {
     }
     
     {
-        my $buttons = $self->CreateStdDialogButtonSizer(wxCLOSE);
+        my $buttons = $self->CreateStdDialogButtonSizer(wxOK);
         EVT_BUTTON($self, wxID_CLOSE, sub {
             $self->_close;
         });


### PR DESCRIPTION
fixes #2881 by replacing wxCLOSE button by wxOK