### PR TITLE
Do not gray out the config option for selecting support interface extruder

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -823,8 +823,7 @@ sub _update {
             support_material_interface_layers dont_support_bridges
             support_material_extrusion_width support_material_contact_distance);
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)
-        for qw(support_material_interface_spacing support_material_interface_extruder
-            support_material_interface_speed);
+        for qw(support_material_interface_spacing support_material_interface_speed);
     
     $self->get_field('perimeter_extrusion_width')->toggle($have_perimeters || $have_skirt || $have_brim);
     $self->get_field('support_material_extruder')->toggle($have_support_material || $have_skirt);


### PR DESCRIPTION
Ubuntu 15.10, slic3r master as of today (83c91a3538661af2447eb0e90489ec55c4a4d52e)

The option was disabled if support interface layers was set to 0.

It sounds reasonable at first, but it seems support interface gets then generated nevertheless in some cases, [by this if](https://github.com/alexrj/Slic3r/blob/master/lib/Slic3r/Print/SupportMaterial.pm#L677). It may be a bit confusing, but I guess it shall be this way for some reasons. To reproduce, try this [STL](http://students.mimuw.edu.pl/~md319428/s/t4.stl) with support: true, support_interface_layers: 0, verbose_gcode:true; then you get such [gcode](http://students.mimuw.edu.pl/~md319428/s/t4-master-si-0-layer.gcode) which contains many "; support material interface".

It is a problem for dual-material printing (say, PLA/PVA) as then user can't change support interface extruder to PVA and gets quite a lot of unwanted PLA.

Anyway, I think we could simply allow user to change it anytime.

Now it could be hacked out by setting support_interface_layers to 1, changing the extruder, and setting back to 0...

// Thanks to the student who found and isolated the problem.