### PR TITLE
Don't toggle support_material_enforce_layers field

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -818,8 +818,8 @@ sub _update {
     my $have_support_material = $config->support_material || $config->raft_layers > 0;
     my $have_support_interface = $config->support_material_interface_layers > 0;
     $self->get_field($_)->toggle($have_support_material)
-        for qw(support_material_threshold support_material_enforce_layers
-            support_material_pattern support_material_spacing support_material_angle
+        for qw(support_material_threshold support_material_pattern
+            support_material_spacing support_material_angle
             support_material_interface_layers dont_support_bridges
             support_material_extrusion_width support_material_contact_distance);
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)


### PR DESCRIPTION
support_material_enforce_layers works independently of the support_material ||
raft options, so we should not disable the field when support material
generation is disabled.

Fixes: #3046