### PR TITLE
Fix issue with undefined BOOST_VERSION

### DIFF
--- a/xs/src/libslic3r/Point.hpp
+++ b/xs/src/libslic3r/Point.hpp
@@ -114,6 +114,7 @@ class Pointf3 : public Pointf
 }
 
 // start Boost
+#include <boost/version.hpp>
 #include <boost/polygon/polygon.hpp>
 namespace boost { namespace polygon {
     template <>


### PR DESCRIPTION
if BOOST_VERSION < 106000 always succeeds because BOOST_VERSION is
undefined.  In order to avoid the code for new boost, we need <boost/version.hpp>

Before adding the fix, verified that this was the issue with:
#ifndef BOOST_VERSION
#error BOOST_VERSION not defined
#endif

I'm compiling on Windows with Boost in C:\dev\boost_1_60_0