### PR TITLE
Work-in-progress addition to add arbitrary gcode after objects when sequential printing.

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -993,7 +993,7 @@ sub build {
         octoprint_host octoprint_apikey
         use_firmware_retraction pressure_advance vibration_limit
         use_volumetric_e
-        start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode
+        start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode after_object_gcode
         nozzle_diameter extruder_offset
         retract_length retract_lift retract_speed retract_restart_extra retract_before_travel retract_layer_change wipe
         retract_length_toolchange retract_restart_extra_toolchange
@@ -1235,6 +1235,15 @@ sub build {
             $option->height(150);
             $optgroup->append_single_option_line($option);
         }
+        {
+            my $optgroup = $page->new_optgroup('Post-object Gcode (sequential printing)',
+                label_width => 0,
+            );
+            my $option = $optgroup->get_option('after_object_gcode');
+            $option->full_width(1);
+            $option->height(150);
+            $optgroup->append_single_option_line($option);
+	}
     }
     
     $self->{extruder_pages} = [];

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -270,6 +270,8 @@ sub export {
                 $finished_objects++;
                 $self->_second_layer_things_done(0);
             }
+            # print after-object gcode
+            printf $fh "%s\n", $gcodegen->placeholder_parser->process($self->config->after_object_gcode);
         }
     } else {
         # order objects using a nearest neighbor search

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -269,9 +269,9 @@ sub export {
                 $self->flush_filters;
                 $finished_objects++;
                 $self->_second_layer_things_done(0);
+                # print after-object gcode
+                printf $fh "%s\n", $gcodegen->placeholder_parser->process($self->config->after_object_gcode);
             }
-            # print after-object gcode
-            printf $fh "%s\n", $gcodegen->placeholder_parser->process($self->config->after_object_gcode);
         }
     } else {
         # order objects using a nearest neighbor search

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -270,6 +270,7 @@ sub export {
                 $finished_objects++;
                 $self->_second_layer_things_done(0);
                 # print after-object gcode
+                print $fh "; Object End\n" if $self->config->gcode_comments;
                 printf $fh "%s\n", $gcodegen->placeholder_parser->process($self->config->after_object_gcode);
             }
         }

--- a/t/custom_gcode.t
+++ b/t/custom_gcode.t
@@ -1,4 +1,4 @@
-use Test::More tests => 15;
+use Test::More tests => 16;
 use strict;
 use warnings;
 
@@ -58,13 +58,10 @@ use Slic3r::Test;
             my ($self, $cmd, $args, $info) = @_;
             
             if ($last_move_was_z_change && $cmd ne $config->layer_gcode) {
-                fail 'custom layer G-code was not applied after Z change';
-            }
-            if (!$last_move_was_z_change && $cmd eq $config->layer_gcode) {
-                fail 'custom layer G-code was not applied after Z change';
+                fail 'custom post-object G-code was not applied after final print move for object';
             }
             
-            $last_move_was_z_change = (defined $info->{dist_Z} && $info->{dist_Z} > 0);
+            $last_move_was_extrusion = (defined $info->{dist_E} && $info->{dist_E} > 0);
         });
         
         1;

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -561,6 +561,15 @@ PrintConfigDef::PrintConfigDef()
     def->height = 50;
     def->default_value = new ConfigOptionString("");
 
+    def = this->add("after_object_gcode", coString);
+    def->label = "After layer change G-code";
+    def->tooltip = "This custom code is inserted after every object during sequential printing ONLY. It is placed immediately after the object's gcode so the user is expected to travel away from the object. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->cli = "after-object-gcode|object-gcode=s";
+    def->multiline = true;
+    def->full_width = true;
+    def->height = 50;
+    def->default_value = new ConfigOptionString("");
+
     def = this->add("layer_height", coFloat);
     def->label = "Layer height";
     def->category = "Layers and Perimeters";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -248,6 +248,7 @@ class GCodeConfig : public virtual StaticPrintConfig
     ConfigOptionBool                gcode_comments;
     ConfigOptionEnum<GCodeFlavor>   gcode_flavor;
     ConfigOptionString              layer_gcode;
+    ConfigOptionString              after_object_gcode;
     ConfigOptionFloat               max_print_speed;
     ConfigOptionFloat               max_volumetric_speed;
     ConfigOptionFloat               pressure_advance;
@@ -292,6 +293,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         OPT_PTR(retract_speed);
         OPT_PTR(start_gcode);
         OPT_PTR(toolchange_gcode);
+        OPT_PTR(after_object_gcode);
         OPT_PTR(travel_speed);
         OPT_PTR(use_firmware_retraction);
         OPT_PTR(use_relative_e_distances);


### PR DESCRIPTION
Fixes #3264.

It's incomplete because I don't know how to properly add items to the Config. I think I have most of it, but it's dying at line 344 lib/Slic3r/GUI/OptionsGroup.pm because it can't find "after_object_gcode" which is the new one. 

XS builds just fine though :)

The test needs work as well, but I'd rather figure out what I'm doing wrong so I can also work out a test.
