### PR TITLE
Pressure advance overrides print speeds patch

### DIFF
--- a/lib/Slic3r/GCode/PressureRegulator.pm
+++ b/lib/Slic3r/GCode/PressureRegulator.pm
@@ -36,7 +36,7 @@ sub process {
         } elsif ($info->{extruding} && $info->{dist_XY} > 0) {
             # This is a print move.
             my $F = $args->{F} // $reader->F;
-            if ($F != $self->_last_print_F || ($F == $self->_last_print_F && $self->_advance = 0)) {
+            if ($F != $self->_last_print_F || ($F == $self->_last_print_F && $self->_advance == 0)) {
                 # We are setting a (potentially) new speed or a discharge event happend since the last speed change, so we calculate the new advance amount.
             
                 # First calculate relative flow rate (mm of filament over mm of travel)

--- a/lib/Slic3r/GCode/PressureRegulator.pm
+++ b/lib/Slic3r/GCode/PressureRegulator.pm
@@ -83,7 +83,7 @@ sub _discharge {
         $self->_extrusion_axis, $new_E, $F // $self->_unretract_speed;
     $gcode .= sprintf "G92 %s%.5f ; restore E\n", $self->_extrusion_axis, $self->reader->E
         if !$self->config->use_relative_e_distances;
-	$gcode .= sprintf "G1 F%.3f ; restore F\n", $F;
+	$gcode .= sprintf "G1 F%.3f ; restore F\n", $args->{F} // $reader->F;
     $self->_advance(0);
     
     return $gcode;


### PR DESCRIPTION
This solves #3282. It resets the print speed after a advance/discharge and it checks if the speed is unchanged, but an advance has to be made because a discharge was done before.

Please note, this is my first own coding acitivity at github and I'm not familiar with perl, only a little bit of C. If some informations are missing for the request, please let me know!
