### PR TITLE
Tweakable xy supports

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -823,7 +823,7 @@ sub _update {
         for qw(support_material_threshold support_material_pattern
             support_material_spacing support_material_angle
             support_material_interface_layers dont_support_bridges
-            support_material_extrusion_width support_material_contact_distance);
+            support_material_extrusion_width support_material_contact_distance support_material_xy_spacing);
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)
         for qw(support_material_interface_spacing support_material_interface_extruder
             support_material_interface_speed);

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -467,6 +467,7 @@ sub build {
         max_print_speed max_volumetric_speed
         perimeter_speed small_perimeter_speed external_perimeter_speed infill_speed 
         solid_infill_speed top_solid_infill_speed support_material_speed 
+        support_material_xy_spacing
         support_material_interface_speed bridge_speed gap_fill_speed
         travel_speed
         first_layer_speed
@@ -588,6 +589,7 @@ sub build {
             $optgroup->append_single_option_line('support_material_angle');
             $optgroup->append_single_option_line('support_material_interface_layers');
             $optgroup->append_single_option_line('support_material_interface_spacing');
+            $optgroup->append_single_option_line('support_material_xy_spacing');
             $optgroup->append_single_option_line('dont_support_bridges');
         }
     }

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -315,7 +315,7 @@ sub object_top {
                 # grow top surfaces so that interface and support generation are generated
                 # with some spacing from object - it looks we don't need the actual
                 # top shapes so this can be done here
-                $top{ $layer->print_z } = offset($touching, $self->flow->scaled_width + $self->object_config->support_material_xy_spacing);
+                $top{ $layer->print_z } = offset($touching, $self->flow->scaled_width + ($self->object_config->support_material_xy_spacing / 0.000001) );
             }
             
             # remove the areas that touched from the projection that will continue on 
@@ -529,7 +529,7 @@ sub clip_with_object {
         # if the user wants to play around with this setting.
         $support->{$i} = diff(
             $support->{$i},
-            offset([ map @$_, map @{$_->slices}, @layers ], +$self->object_config->support_material_xy_spacing),
+            offset([ map @$_, map @{$_->slices}, @layers ], +($self->flow->scaled_width +($self->object_config->support_material_xy_spacing / 0.000001))),
         );
     }
 }
@@ -542,7 +542,7 @@ sub generate_toolpaths {
     
     # shape of contact area
     my $contact_loops   = 1;
-    my $circle_radius   = 1.5 * $interface_flow->scaled_width;
+    my $circle_radius   = 1.5 * $interface_flow->scaled_width - ($self->object_config->support_material_xy_spacing / 0.000001) ;
     my $circle_distance = 3 * $circle_radius;
     my $circle          = Slic3r::Polygon->new(map [ $circle_radius * cos $_, $circle_radius * sin $_ ],
                             (5*PI/3, 4*PI/3, PI, 2*PI/3, PI/3, 0));
@@ -612,7 +612,7 @@ sub generate_toolpaths {
             # generate the outermost loop
             
             # find centerline of the external loop (or any other kind of extrusions should the loop be skipped)
-            $contact = offset($contact, -$_interface_flow->scaled_width/2);
+            $contact = offset($contact, -($_interface_flow->scaled_width + ($self->object_config->support_material_xy_spacing / 0.000001)) /2);
             
             my @loops0 = ();
             {

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -315,7 +315,7 @@ sub object_top {
                 # grow top surfaces so that interface and support generation are generated
                 # with some spacing from object - it looks we don't need the actual
                 # top shapes so this can be done here
-                $top{ $layer->print_z } = offset($touching, $self->flow->scaled_width);
+                $top{ $layer->print_z } = offset($touching, $self->flow->scaled_width + $self->object_config->support_material_xy_spacing);
             }
             
             # remove the areas that touched from the projection that will continue on 
@@ -525,10 +525,11 @@ sub clip_with_object {
         # $layer->slices contains the full shape of layer, thus including
         # perimeter's width. $support contains the full shape of support
         # material, thus including the width of its foremost extrusion.
-        # We leave a gap equal to a full extrusion width.
+        # We leave a gap equal to a full extrusion width + an offset
+        # if the user wants to play around with this setting.
         $support->{$i} = diff(
             $support->{$i},
-            offset([ map @$_, map @{$_->slices}, @layers ], +$self->flow->scaled_width),
+            offset([ map @$_, map @{$_->slices}, @layers ], +$self->object_config->support_material_xy_spacing),
         );
     }
 }

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -419,6 +419,9 @@ $j
                         Support material angle in degrees (range: 0-90, default: $config->{support_material_angle})
     --support-material-contact-distance
                         Vertical distance between object and support material (0+, default: $config->{support_material_contact_distance})
+
+    --support-material-xy-spacing
+                        horizontal distance between object and support material (0+, default: $config->{support_material_xy_spacing})
     --support-material-interface-layers
                         Number of perpendicular layers between support material and object (0+, default: $config->{support_material_interface_layers})
     --support-material-interface-spacing

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1038,6 +1038,13 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "support-material!";
     def->default_value = new ConfigOptionBool(false);
 
+    def = this->add("support_material_xy_spacing", coFloat);
+    def->label = "Extra separation between part and support (mm)";
+    def->category = "Support material";
+    def->tooltip = "Add offset to support material separation (0 is 1 extrusion width).";
+    def->cli = "support-material-xy-spacing=f";
+    def->default_value = new ConfigOptionFloat(0.0);
+
     def = this->add("support_material_angle", coInt);
     def->label = "Pattern angle";
     def->category = "Support material";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -124,6 +124,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     ConfigOptionFloat               support_material_spacing;
     ConfigOptionFloat               support_material_speed;
     ConfigOptionInt                 support_material_threshold;
+    ConfigOptionFloat               support_material_xy_spacing;
     ConfigOptionFloat               xy_size_compensation;
     
     PrintObjectConfig() : StaticPrintConfig() {
@@ -152,6 +153,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
         OPT_PTR(support_material_pattern);
         OPT_PTR(support_material_spacing);
         OPT_PTR(support_material_speed);
+        OPT_PTR(support_material_xy_spacing);
         OPT_PTR(support_material_threshold);
         OPT_PTR(xy_size_compensation);
         

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -236,6 +236,7 @@ PrintObject::invalidate_state_by_config_options(const std::vector<t_config_optio
             || *opt_key == "support_material_interface_spacing"
             || *opt_key == "support_material_interface_speed"
             || *opt_key == "support_material_pattern"
+            || *opt_key == "support_material_xy_spacing"
             || *opt_key == "support_material_spacing"
             || *opt_key == "support_material_threshold"
             || *opt_key == "dont_support_bridges"


### PR DESCRIPTION
Added option to increase XY supports (addresses #2916 and #3298), through a new config option and adjusting the clip_with_object and the contact layer. Defaults to 0 (current behavior), and may cause weird things to happen with support generation if set high. 

May be useful to adjust the minimum span to support to include this value as well. 
