### PR TITLE
Fix layer cooldown time

### DIFF
--- a/lib/Slic3r/GCode/CoolingBuffer.pm
+++ b/lib/Slic3r/GCode/CoolingBuffer.pm
@@ -56,7 +56,7 @@ sub flush {
         Slic3r::debugf "  fan = %d%%, speed = %d%%\n", $fan_speed, $speed_factor * 100;
         
         if ($speed_factor < 1) {
-            $gcode =~ s/^(?=.*? [XY])(?=.*? E)(?!;_WIPE)(?<!;_BRIDGE_FAN_START\n)(G1 .*?F)(\d+(?:\.\d+)?)/
+            $gcode =~ s/^(?=.*?;_EXTRUDE_SET_SPEED)(?!.*?;_WIPE)(?<!;_BRIDGE_FAN_START\n)(G1\sF)(\d+(?:\.\d+)?)/
                 my $new_speed = $2 * $speed_factor;
                 $1 . sprintf("%.3f", $new_speed < $self->min_print_speed ? $self->min_print_speed : $new_speed)
                 /gexm;
@@ -73,6 +73,7 @@ sub flush {
         $gcode =~ s/^;_BRIDGE_FAN_END\n/ $self->gcodegen->writer->set_fan($fan_speed, 1) /gmex;
     }
     $gcode =~ s/;_WIPE//g;
+    $gcode =~ s/;_EXTRUDE_SET_SPEED//g;
     
     return $gcode;
 }

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -198,7 +198,7 @@ Wipe::wipe(GCode &gcodegen, bool toolchange)
 
 GCode::GCode()
     : placeholder_parser(NULL), enable_loop_clipping(true), enable_cooling_markers(false), layer_count(0),
-        layer_index(-1), layer(NULL), first_layer(false), elapsed_time(0), volumetric_speed(0),
+        layer_index(-1), layer(NULL), first_layer(false), elapsed_time(0.0), volumetric_speed(0),
         _last_pos_defined(false)
 {
 }

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -177,11 +177,11 @@ Wipe::wipe(GCode &gcodegen, bool toolchange)
             /*  Reduce retraction length a bit to avoid effective retraction speed to be greater than the configured one
                 due to rounding (TODO: test and/or better math for this)  */
             double dE = length * (segment_length / wipe_dist) * 0.95;
-            gcode += gcodegen.writer.set_speed(wipe_speed*60);
+            gcode += gcodegen.writer.set_speed(wipe_speed*60, gcodegen.enable_cooling_markers ? ";_WIPE" : "");
             gcode += gcodegen.writer.extrude_to_xy(
                 gcodegen.point_to_gcode(line->b),
                 -dE,
-                (std::string)"wipe and retract" + (gcodegen.enable_cooling_markers ? ";_WIPE" : "")
+                "wipe and retract"
             );
             retracted += dE;
         }
@@ -562,7 +562,7 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
     // extrude arc or line
     if (path.is_bridge() && this->enable_cooling_markers)
         gcode += ";_BRIDGE_FAN_START\n";
-    gcode += this->writer.set_speed(F);
+    gcode += this->writer.set_speed(F, this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
     double path_length = 0;
     {
         std::string comment = this->config.gcode_comments ? description : "";

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -629,9 +629,17 @@ GCode::travel_to(const Point &point, ExtrusionRole role, std::string comment)
     
     // use G1 because we rely on paths being straight (G0 may make round paths)
     Lines lines = travel.lines();
-    for (Lines::const_iterator line = lines.begin(); line != lines.end(); ++line)
-        gcode += this->writer.travel_to_xy(this->point_to_gcode(line->b), comment);
-    
+    double path_length = 0;
+    for (Lines::const_iterator line = lines.begin(); line != lines.end(); ++line) {
+	    const double line_length = line->length() * SCALING_FACTOR;
+	    path_length += line_length;
+
+	    gcode += this->writer.travel_to_xy(this->point_to_gcode(line->b), comment);
+    }
+
+    if (this->config.cooling)
+        this->elapsed_time += path_length / this->config.get_abs_value("travel_speed");
+
     return gcode;
 }
 

--- a/xs/src/libslic3r/GCode.hpp
+++ b/xs/src/libslic3r/GCode.hpp
@@ -82,7 +82,7 @@ class GCode {
     const Layer* layer;
     std::map<const PrintObject*,Point> _seam_position;
     bool first_layer; // this flag triggers first layer speeds
-    unsigned int elapsed_time; // seconds
+    float elapsed_time; // seconds
     double volumetric_speed;
     
     GCode();

--- a/xs/xsp/GCode.xsp
+++ b/xs/xsp/GCode.xsp
@@ -129,9 +129,9 @@
     void set_first_layer(bool value)
         %code{% THIS->first_layer = value; %};
     
-    unsigned int elapsed_time()
+    float elapsed_time()
         %code{% RETVAL = THIS->elapsed_time; %};
-    void set_elapsed_time(unsigned int value)
+    void set_elapsed_time(float value)
         %code{% THIS->elapsed_time = value; %};
     
     bool last_pos_defined();


### PR DESCRIPTION
The recent GCode writer changes which put the speed changes on a line of
their own have caused the layer time slowdown to be ignored by the regex
in CoolingBuffer.pm.