### PR TITLE
allow to hide the "controller" tab

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -53,6 +53,8 @@ use constant FILE_WILDCARDS => {
 use constant MODEL_WILDCARD => join '|', @{&FILE_WILDCARDS}{qw(known stl obj amf)};
 
 our $datadir;
+# If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
+our $no_controller;
 our $no_plater;
 our $mode;
 our $autosave;
@@ -64,6 +66,9 @@ our $Settings = {
         version_check => 1,
         autocenter => 1,
         background_processing => 1,
+        # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
+        # By default, Prusa has the controller hidden.
+        no_controller => 1,
     },
 };
 
@@ -115,6 +120,8 @@ sub OnInit {
         $Settings->{_}{mode} ||= 'expert';
         $Settings->{_}{autocenter} //= 1;
         $Settings->{_}{background_processing} //= 1;
+        # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
+        $Settings->{_}{no_controller} //= 1;
     }
     $Settings->{_}{version} = $Slic3r::VERSION;
     $self->save_settings;
@@ -122,8 +129,10 @@ sub OnInit {
     # application frame
     Wx::Image::AddHandler(Wx::PNGHandler->new);
     $self->{mainframe} = my $frame = Slic3r::GUI::MainFrame->new(
-        mode        => $mode // $Settings->{_}{mode},
-        no_plater   => $no_plater,
+        mode            => $mode // $Settings->{_}{mode},
+        # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
+        no_controller   => $no_controller // $Settings->{_}{no_controller},
+        no_plater       => $no_plater,
     );
     $self->SetTopWindow($frame);
     

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -58,6 +58,13 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{background_processing},
         readonly    => !$Slic3r::have_threads,
     ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+        opt_id      => 'no_controller',
+        type        => 'bool',
+        label       => 'Disable USB/serial connection',
+        tooltip     => 'Disable communication with the printer over a serial / USB cable. This simplifies the user interface in case the printer is never attached to the computer.',
+        default     => $Slic3r::GUI::Settings->{_}{no_controller},
+    ));
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);
     $sizer->Add($optgroup->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);
@@ -75,7 +82,7 @@ sub new {
 sub _accept {
     my $self = shift;
     
-    if ($self->{values}{mode}) {
+    if ($self->{values}{mode} || defined($self->{values}{no_controller})) {
         Slic3r::GUI::warning_catcher($self)->("You need to restart Slic3r to make the changes effective.");
     }
     

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -107,7 +107,7 @@ sub new {
     });
     
     $self->{config} = Slic3r::Config->new;
-    $self->build;
+    $self->build(%params);
     $self->update_tree;
     $self->_update;
     if ($self->hidden_options) {
@@ -985,6 +985,7 @@ sub title { 'Printer Settings' }
 
 sub build {
     my $self = shift;
+    my (%params) = @_;
     
     $self->init_config_options(qw(
         bed_shape z_offset
@@ -1064,6 +1065,7 @@ sub build {
                 }
             });
         }
+        if (!$params{no_controller})
         {
             my $optgroup = $page->new_optgroup('USB/Serial connection');
             my $line = Slic3r::GUI::OptionsGroup::Line->new(
@@ -1239,7 +1241,7 @@ sub build {
     
     $self->{extruder_pages} = [];
     $self->_build_extruder_pages;
-    $self->_update_serial_ports;
+    $self->_update_serial_ports if (!$params{no_controller});
 }
 
 sub _update_serial_ports {
@@ -1341,11 +1343,14 @@ sub _update {
     
     my $config = $self->{config};
     
-    $self->get_field('serial_speed')->toggle($config->get('serial_port'));
-    if ($config->get('serial_speed') && $config->get('serial_port')) {
-        $self->{serial_test_btn}->Enable;
-    } else {
-        $self->{serial_test_btn}->Disable;
+    my $serial_speed = $self->get_field('serial_speed');
+    if ($serial_speed) {
+        $self->get_field('serial_speed')->toggle($config->get('serial_port'));
+        if ($config->get('serial_speed') && $config->get('serial_port')) {
+            $self->{serial_test_btn}->Enable;
+        } else {
+            $self->{serial_test_btn}->Disable;
+        }
     }
     if ($config->get('octoprint_host') && eval "use LWP::UserAgent; 1") {
         $self->{octoprint_host_test_btn}->Enable;

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -32,6 +32,7 @@ my %cli_options = ();
         'load=s@'               => \$opt{load},
         'autosave=s'            => \$opt{autosave},
         'ignore-nonexistent-config' => \$opt{ignore_nonexistent_config},
+        'no-controller'         => \$opt{no_controller},
         'no-plater'             => \$opt{no_plater},
         'gui-mode=s'            => \$opt{gui_mode},
         'datadir=s'             => \$opt{datadir},
@@ -99,10 +100,11 @@ my $gui;
 if ((!@ARGV || $opt{gui}) && !$opt{save} && eval "require Slic3r::GUI; 1") {
     {
         no warnings 'once';
-        $Slic3r::GUI::datadir   = Slic3r::decode_path($opt{datadir} // '');
-        $Slic3r::GUI::no_plater = $opt{no_plater};
-        $Slic3r::GUI::mode      = $opt{gui_mode};
-        $Slic3r::GUI::autosave  = $opt{autosave};
+        $Slic3r::GUI::datadir       = Slic3r::decode_path($opt{datadir} // '');
+        $Slic3r::GUI::no_controller = $opt{no_controller};
+        $Slic3r::GUI::no_plater     = $opt{no_plater};
+        $Slic3r::GUI::mode          = $opt{gui_mode};
+        $Slic3r::GUI::autosave      = $opt{autosave};
     }
     $gui = Slic3r::GUI->new;
     setlocale(LC_NUMERIC, 'C');


### PR DESCRIPTION
The "controller" tab and the settings of the USB/serial connection was
made configurable. Now one may hide the "controller" tab and the USB/serial
connection configuration from the preferences. This is useful for someone,
who never connects his printer to the computer by a cable.
This feature was proposed by Josef Prusa of Prusa3D.