### PR TITLE
Workaround #3220

### DIFF
--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -564,9 +564,7 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
     if (path.is_bridge() && this->enable_cooling_markers)
         gcode += ";_BRIDGE_FAN_START\n";
 
-    if (F > 0) 
-      // don't reset speed if nonpositive
-      gcode += this->writer.set_speed(F, "", this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
+    gcode += this->writer.set_speed(F, "", this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
     double path_length = 0;
     {
         std::string comment = this->config.gcode_comments ? description : "";

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -558,12 +558,15 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
             this->config.max_volumetric_speed.value / path.mm3_per_mm
         );
     }
-    double F = speed * 60;  // convert mm/sec to mm/min
+    double F = speed * 60.0;  // convert mm/sec to mm/min
     
     // extrude arc or line
     if (path.is_bridge() && this->enable_cooling_markers)
         gcode += ";_BRIDGE_FAN_START\n";
-    gcode += this->writer.set_speed(F, "", this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
+
+    if (F <= 0) 
+      // don't reset speed if nonpositive
+      gcode += this->writer.set_speed(F, "", this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
     double path_length = 0;
     {
         std::string comment = this->config.gcode_comments ? description : "";

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -564,7 +564,7 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
     if (path.is_bridge() && this->enable_cooling_markers)
         gcode += ";_BRIDGE_FAN_START\n";
 
-    if (F <= 0) 
+    if (F > 0) 
       // don't reset speed if nonpositive
       gcode += this->writer.set_speed(F, "", this->enable_cooling_markers ? ";_EXTRUDE_SET_SPEED" : "");
     double path_length = 0;

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -277,7 +277,10 @@ GCodeWriter::set_speed(double F, const std::string &comment,
                        const std::string &cooling_marker) const
 {
     std::ostringstream gcode;
-    gcode << "G1 F" << F;
+    if (F < 0.0)
+      gcode << "; Skipped writing G1 F" << F << " because it was <= 0";
+    else 
+      gcode << "G1 F" << F;
     COMMENT(comment);
     gcode << cooling_marker;
     gcode << "\n";


### PR DESCRIPTION
Workaround to at least enforce no surprise negative feedrates on extrude moves.  What really needs to happen, I think, is there should be an assertion (or CONFESS()) call so it can be debugged up at where it is generated. However, that's probably less than ideal for a majority of users, so this omits the speed change command if the feedrate is negative or 0 (both of which are illegal so far as I know). 

Fixes/works around #3220 and #3045