### PR TITLE
Implemented configurable width for skirt lines.

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -46,7 +46,7 @@ sub new {
     my ($parent) = @_;
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
     $self->{config} = Slic3r::Config->new_from_defaults(qw(
-        bed_shape complete_objects extruder_clearance_radius skirts skirt_distance brim_width
+        bed_shape complete_objects extruder_clearance_radius skirts skirt_distance brim_width skirt_width
         serial_port serial_speed octoprint_host octoprint_apikey
     ));
     $self->{model} = Slic3r::Model->new;

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -472,7 +472,7 @@ sub build {
         first_layer_speed
         perimeter_acceleration infill_acceleration bridge_acceleration 
         first_layer_acceleration default_acceleration
-        skirts skirt_distance skirt_height min_skirt_length
+        skirts skirt_distance skirt_height min_skirt_length skirt_width
         brim_width
         support_material support_material_threshold support_material_enforce_layers
         raft_layers
@@ -561,6 +561,7 @@ sub build {
             $optgroup->append_single_option_line('skirt_distance');
             $optgroup->append_single_option_line('skirt_height');
             $optgroup->append_single_option_line('min_skirt_length');
+            $optgroup->append_single_option_line('skirt_width');
         }
         {
             my $optgroup = $page->new_optgroup('Brim');

--- a/xs/src/libslic3r/Flow.cpp
+++ b/xs/src/libslic3r/Flow.cpp
@@ -49,6 +49,19 @@ Flow::spacing() const {
     float min_flow_spacing = this->width - this->height * (1 - PI/4.0);
     return this->width - OVERLAP_FACTOR * (this->width - min_flow_spacing);
 }
+/* This method returns the centerline spacing between two adjacent extrusions 
+   having the same supplied extrusion width (and other properties) */
+
+float
+Flow::spacing(const float width) const {
+    if (this->bridge) {
+        return width + BRIDGE_EXTRA_SPACING;
+    }
+    
+    // rectangle with semicircles at the ends
+    float min_flow_spacing = width - this->height * (1 - PI/4.0);
+    return width - OVERLAP_FACTOR * (width - min_flow_spacing);
+}
 
 /* This method returns the centerline spacing between an extrusion using this
    flow and another one using another flow.
@@ -74,6 +87,17 @@ Flow::mm3_per_mm() const {
     
     // rectangle with semicircles at the ends
     return this->width * this->height + (this->height*this->height) / 4.0 * (PI-4.0);
+}
+
+/* This method returns extrusion volume per head move unit for a different width */
+double
+Flow::mm3_per_mm(float width) const {
+    if (this->bridge) {
+        return (width * width) * PI/4.0;
+    }
+    
+    // rectangle with semicircles at the ends
+    return width * this->height + (this->height*this->height) / 4.0 * (PI-4.0);
 }
 
 /* This static method returns bridge width for a given nozzle diameter. */

--- a/xs/src/libslic3r/Flow.hpp
+++ b/xs/src/libslic3r/Flow.hpp
@@ -29,8 +29,10 @@ class Flow
     Flow(float _w, float _h, float _nd, bool _bridge = false)
         : width(_w), height(_h), nozzle_diameter(_nd), bridge(_bridge) {};
     float spacing() const;
+    float spacing(const float width) const;
     float spacing(const Flow &other) const;
     double mm3_per_mm() const;
+    double mm3_per_mm(float width) const;
     coord_t scaled_width() const {
         return scale_(this->width);
     };

--- a/xs/src/libslic3r/Print.cpp
+++ b/xs/src/libslic3r/Print.cpp
@@ -167,6 +167,7 @@ Print::invalidate_state_by_config_options(const std::vector<t_config_option_key>
             || *opt_key == "skirt_height"
             || *opt_key == "skirt_distance"
             || *opt_key == "min_skirt_length"
+            || *opt_key == "skirt_width"
             || *opt_key == "ooze_prevention") {
             steps.insert(psSkirt);
         } else if (*opt_key == "brim_width") {

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -622,6 +622,14 @@ PrintConfigDef::PrintConfigDef()
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
+    def = this->add("skirt_width", coFloat);
+    def->label = "Skirt extrusion width";
+    def->tooltip = "Specify the width of the skirt placement in mm. Useful for priming moves. Use '0' to use the default extrusion width for the first layer.";
+    def->sidetext = "mm";
+    def->cli = "skirt-width=f";
+    def->min = 0;
+    def->default_value = new ConfigOptionFloat(0);
+
     def = this->add("notes", coString);
     def->label = "Configuration notes";
     def->tooltip = "You can put here your personal notes. This text will be added to the G-code header comments.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -355,6 +355,7 @@ class PrintConfig : public GCodeConfig
     ConfigOptionFloat               resolution;
     ConfigOptionFloats              retract_before_travel;
     ConfigOptionBools               retract_layer_change;
+    ConfigOptionFloat               skirt_width;
     ConfigOptionFloat               skirt_distance;
     ConfigOptionInt                 skirt_height;
     ConfigOptionInt                 skirts;
@@ -411,6 +412,7 @@ class PrintConfig : public GCodeConfig
         OPT_PTR(resolution);
         OPT_PTR(retract_before_travel);
         OPT_PTR(retract_layer_change);
+        OPT_PTR(skirt_width);
         OPT_PTR(skirt_distance);
         OPT_PTR(skirt_height);
         OPT_PTR(skirts);

--- a/xs/xsp/Flow.xsp
+++ b/xs/xsp/Flow.xsp
@@ -24,11 +24,15 @@
     bool bridge()
         %code{% RETVAL = THIS->bridge; %};
     float spacing();
+    float spacing_width(float width)
+        %code{% RETVAL = THIS->spacing(width); %};
     float spacing_to(Flow* other)
         %code{% RETVAL = THIS->spacing(*other); %};
     long scaled_width();
     long scaled_spacing();
     double mm3_per_mm();
+    double mm3_per_mm_width(float width)
+        %code{% RETVAL = THIS->mm3_per_mm(width); %};
 %{
 
 Flow*


### PR DESCRIPTION
This is useful for priming skirts.
Also added functions to Slic3r::Flow() to calculate spacing and mm3_per_mm for alternate flow widths (as trying to generate an new one crashed slic3r).
Addresses #1333.
