### PR TITLE
Support multi sampled anti-aliasing with wxWidgets 3.0.3.

### DIFF
--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -143,10 +143,16 @@ __PACKAGE__->mk_accessors(qw(
 sub new {
     my ($class, $parent, $print) = @_;
     
-    my $self = $class->SUPER::new($parent);
+    my $self = (Wx::wxVERSION >= 3.000003) ?
+        # The wxWidgets 3.0.3-beta have a bug, they crash with NULL attribute list.
+        $class->SUPER::new($parent, -1, Wx::wxDefaultPosition, Wx::wxDefaultSize, 0, "",
+            [WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 24, 0]) :
+        $class->SUPER::new($parent);
+    # Immediatelly force creation of the OpenGL context to consume the static variable s_wglContextAttribs.
+    $self->GetContext();
     $self->print($print);
     $self->_zoom(1);
-    
+
     # 2D point in model space
     $self->_camera_target(Slic3r::Pointf->new(0,0));
     


### PR DESCRIPTION
Cherry-picked the changes into their own branch for clean merging. What follows below is the original post (#3343)

https://github.com/alexrj/Slic3r/files/295253/Patches.zip is required to test/view MSAA with wxWidgets 3.0.3
------------------
This patch improves rendering of the 3D scenes. The improvement is significant on the 3D path simulation.

1) Increases resolution of the depth buffer from 16 bits to 24 bits. 16 bits cause some jagged lines at the intersection of triangles. I believe the computers offering a 16 bit depth buffer only are already in the landfill.

2) Enables multi sample anti aliasing. This is finally supported by wxWidgets 3.1 (February 29, 2016) and the OpenGL support for creation of anti aliased windows has been back ported to wxWidgets 3.0.3 (currently in beta stage). We at Prusa Research have hacked the Alien::Wx and Wx::GLCanvas to support this feature. Please accept this patch to enable anti aliasing on Prusa builds. This change shall not have any effect with the official non-hacked Alien::Wx and Wx::GLCanvas modules.

Vojtech