### PR TITLE
infill_only_where_needed is incompatible with spiral_vase: enforced.

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -737,13 +737,14 @@ sub _update {
     
     my $config = $self->{config};
     
-    if ($config->spiral_vase && !($config->perimeters == 1 && $config->top_solid_layers == 0 && $config->fill_density == 0)) {
+    if ($config->spiral_vase && !($config->perimeters == 1 && $config->top_solid_layers == 0 && $config->fill_density == 0 && $config->infill_only_where_needed == 0 && $config->support_material == 0)) {
         my $dialog = Wx::MessageDialog->new($self,
             "The Spiral Vase mode requires:\n"
             . "- one perimeter\n"
             . "- no top solid layers\n"
             . "- 0% fill density\n"
             . "- no support material\n"
+            . "- no infill where necessary\n"
             . "\nShall I adjust those settings in order to enable Spiral Vase?",
             'Spiral Vase', wxICON_WARNING | wxYES | wxNO);
         if ($dialog->ShowModal() == wxID_YES) {
@@ -752,6 +753,7 @@ sub _update {
             $new_conf->set("top_solid_layers", 0);
             $new_conf->set("fill_density", 0);
             $new_conf->set("support_material", 0);
+            $new_conf->set("infill_only_where_needed", 0);
             $self->load_config($new_conf);
         } else {
             my $new_conf = Slic3r::Config->new;

--- a/lib/Slic3r/Print/Object.pm
+++ b/lib/Slic3r/Print/Object.pm
@@ -723,7 +723,9 @@ sub detect_surfaces_type {
 # fill_surfaces but we only turn them into VOID surfaces, thus preserving the boundaries.
 sub clip_fill_surfaces {
     my $self = shift;
-    return unless $self->config->infill_only_where_needed;
+    # sanity check for incompatible options: 
+    #   spiral_vase and infill_only_where_needed
+    return unless $self->config->infill_only_where_needed and not $self->config->spiral_vase;
     
     # We only want infill under ceilings; this is almost like an
     # internal support material.


### PR DESCRIPTION
Also ensured that support is disabled if spiral_vase is on.
Added a secondary check to make sure that clip_fill_surfaces does not run if we're in spiral_vase.

Fixes #3126 