### PR TITLE
Set LDLOADLIBS to get the linker switch to occur in the right place.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: perl
-install: true
+install: export LDLOADLIBS=-lstdc++
 script: perl ./Build.PL
 perl:
   - "5.14"


### PR DESCRIPTION
Fixes #3345 and replaces #3395 Thanks to @hyperair for investigating this. 