### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
   - export BOOST_DIR=$HOME/boost_1_58_0
-  - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
-  - ln -sf $BOOST_DIR/boost $BOOST_DIR/include
+  - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc link=static runtime-link=static variant=release; fi
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: perl
 install: 
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
+  - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
+  - ln -sf $BOOST_DIR/boost $BOOST_DIR/include
   - cd $BUILD_DIR
-script: BOOST_ROOT=$HOME/boost_1_58_0 perl ./Build.PL
+script: perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: perl
-install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=/tmp/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && bash bootstrap.sh gcc && ./b2 
+install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$(HOME)/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 $(HOME)/boost && cd $(HOME)/boost && ./bootstrap.sh gcc && ./b2 
 script: perl ./Build.PL
 perl:
   - "5.14"
@@ -12,4 +12,4 @@ branches:
 sudo: false
 cache:
     directories:
-    - /tmp/boost
+    - $(HOME)/boost

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BOOST_DIR=$HOME/boost_1_58_0 
   - export BUILD_DIR=$(pwd)
-  - if [ -d $HOME/boost_1_58_0 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; fi
-  - if [ -d $HOME/boost_1_58_0 ]; then tar -xf boost_1_58_0.tar.bz2; fi
-  - if [ -d $HOME/boost_1_58_0 ]; then mv boost_1_58_0 $HOME; fi
-  - if [ -d $HOME/boost_1_58_0 ]; then cd $HOME/boost_1_58_0; fi
-  - if [ -d $HOME/boost_1_58_0 ]; then $HOME/boost_1_58_0/bootstrap.sh gcc; fi
-  - if [ -d $HOME/boost_1_58_0 ]; then $HOME/boost_1_58_0/b2; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then tar -xf boost_1_58_0.tar.bz2; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then mv boost_1_58_0 $HOME; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then cd $HOME/boost_1_58_0; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then $HOME/boost_1_58_0/bootstrap.sh gcc; fi
+  - if [ -d "$HOME/boost_1_58_0" ]; then $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
   - export FORCE_BOOST=1
+  - cpanm local::lib
+  - eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ ! -d "$BOOST_DIR" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ install:
   - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
   - tar -xf boost_1_58_0.tar.bz2
   - cd $HOME/boost_1_58_0
-  - ./bootstrap.sh gcc
-  - ./b2 
+  - $HOME/boost_1_58_0/bootstrap.sh gcc
+  - $HOME/boost_1_58_0/b2 
 script: perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: perl
 install: export LDLOADLIBS=-lstdc++
-script: export BOOST_DIR=/usr/include/boost; perl ./Build.PL
+script: 
+export BOOST_DIR=$HOME/boost; 
+wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
+perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"
@@ -12,10 +15,5 @@ branches:
 sudo: false
 cache:
     - apt
-addons:
-  apt:
-    sources:
-    - boost-latest
-    packages:
-    - libboost-thread1.55-dev
-    - libboost-system1.55-dev
+    directories:
+    - /tmp/boost

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ ! -d "$BOOST_DIR" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
+  - export LD_LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib
 script: LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
   - export BOOST_DIR=$HOME/boost_1_58_0
-  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc link=static runtime-link=static variant=release
+  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc variant=release
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BOOST_DIR=$HOME/boost_1_58_0 
   - export BUILD_DIR=$(pwd)
-  - if [ -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; fi
-  - if [ -d "$HOME/boost_1_58_0" ]; then tar -xf boost_1_58_0.tar.bz2; fi
-  - if [ -d "$HOME/boost_1_58_0" ]; then mv boost_1_58_0 $HOME; fi
-  - if [ -d "$HOME/boost_1_58_0" ]; then cd $HOME/boost_1_58_0; fi
-  - if [ -d "$HOME/boost_1_58_0" ]; then $HOME/boost_1_58_0/bootstrap.sh gcc; fi
-  - if [ -d "$HOME/boost_1_58_0" ]; then $HOME/boost_1_58_0/b2; fi
+  - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: perl
-install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$HOME/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 $HOME/boost && cd $HOME/boost && ./bootstrap.sh gcc && ./b2 
+install: 
+  - export LDLOADLIBS=-lstdc++ 
+  - export BOOST_DIR=$HOME/boost 
+  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
+  - tar -xf boost_1_58_0.tar.bz2
+  - mv boost_1_58_0 $HOME/boost
+  - cd $HOME/boost
+  - ./bootstrap.sh gcc
+  - ./b2 
 script: perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: perl
-install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$(HOME)/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 $(HOME)/boost && cd $(HOME)/boost && ./bootstrap.sh gcc && ./b2 
+install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$HOME/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 $HOME/boost && cd $HOME/boost && ./bootstrap.sh gcc && ./b2 
 script: perl ./Build.PL
 perl:
   - "5.14"
@@ -12,4 +12,4 @@ branches:
 sudo: false
 cache:
     directories:
-    - $(HOME)/boost
+    - $HOME/boost

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: perl
 install: 
   - export LDLOADLIBS=-lstdc++ 
-  - export BOOST_DIR=$HOME/boost_1_58_0 
   - export BUILD_DIR=$(pwd)
   - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
-script: perl ./Build.PL
+script: BOOST_ROOT=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
   - export BOOST_DIR=$HOME/boost_1_58_0
-  - if [ ! -d "$HOME/boost_1_58_0" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc link=static runtime-link=static variant=release; fi
+  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc link=static runtime-link=static variant=release
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: perl
 install: 
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
+  - export FORCE_BOOST=1
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   - export BUILD_DIR=$(pwd)
   - export FORCE_BOOST=1
   - export BOOST_DIR=$HOME/boost_1_58_0
-  - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
+  - if [ ! -d "$BOOST_DIR" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
 script: LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: perl
 install: 
   - export LDLOADLIBS=-lstdc++ 
   - export BOOST_DIR=$HOME/boost_1_58_0 
+  - export BUILD_DIR=$(pwd)
   - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
   - tar -xf boost_1_58_0.tar.bz2
   - mv boost_1_58_0 $HOME
   - cd $HOME/boost_1_58_0
   - $HOME/boost_1_58_0/bootstrap.sh gcc
   - $HOME/boost_1_58_0/b2 
+  - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
-script: perl ./Build.PL
+script: CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: perl
-install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$HOME/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
+install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=/tmp/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && bash bootstrap.sh gcc && ./b2 
 script: perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0 
   - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
   - tar -xf boost_1_58_0.tar.bz2
+  - mv boost_1_58_0 $HOME
   - cd $HOME/boost_1_58_0
   - $HOME/boost_1_58_0/bootstrap.sh gcc
   - $HOME/boost_1_58_0/b2 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: perl
 install: export LDLOADLIBS=-lstdc++
 script: 
-export BOOST_DIR=$HOME/boost; 
-wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
-perl ./Build.PL
+  export BOOST_DIR=$HOME/boost
+  wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
+  perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
-script: LIBRARY_PATH=$HOME/boost_1_58_0/bin.v2/libs CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
+script: LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BUILD_DIR=$(pwd)
   - export BOOST_DIR=$HOME/boost_1_58_0
-  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2 toolset=gcc variant=release
+  - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ install:
   - export LDLOADLIBS=-lstdc++ 
   - export BOOST_DIR=$HOME/boost_1_58_0 
   - export BUILD_DIR=$(pwd)
-  - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
-  - tar -xf boost_1_58_0.tar.bz2
-  - mv boost_1_58_0 $HOME
-  - cd $HOME/boost_1_58_0
-  - $HOME/boost_1_58_0/bootstrap.sh gcc
-  - $HOME/boost_1_58_0/b2 
+  - if [ -d $HOME/boost_1_58_0 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; fi
+  - if [ -d $HOME/boost_1_58_0 ]; then tar -xf boost_1_58_0.tar.bz2; fi
+  - if [ -d $HOME/boost_1_58_0 ]; then mv boost_1_58_0 $HOME; fi
+  - if [ -d $HOME/boost_1_58_0 ]; then cd $HOME/boost_1_58_0; fi
+  - if [ -d $HOME/boost_1_58_0 ]; then $HOME/boost_1_58_0/bootstrap.sh gcc; fi
+  - if [ -d $HOME/boost_1_58_0 ]; then $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
 script: perl ./Build.PL
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ 1 ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
-script: CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
+script: LIBRARY_PATH=$HOME/boost_1_58_0/bin.v2/libs CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: perl
 install: export LDLOADLIBS=-lstdc++
-script: perl ./Build.PL
+script: export BOOST_DIR=/usr/include/boost; perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - export BOOST_DIR=$HOME/boost_1_58_0
   - if [ ! -d "$BOOST_DIR" ]; then wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2; tar -xf boost_1_58_0.tar.bz2; mv boost_1_58_0 $HOME; cd $HOME/boost_1_58_0;$HOME/boost_1_58_0/bootstrap.sh gcc; $HOME/boost_1_58_0/b2; fi
   - cd $BUILD_DIR
-  - export LD_LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib
+# Add our local boost version to the environment.
+  - export LD_LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib:${LD_LIBRARY_PATH}
 script: LIBRARY_PATH=$HOME/boost_1_58_0/stage/lib CPLUS_INCLUDE_PATH=$HOME/boost_1_58_0 perl ./Build.PL
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: perl
-install: export LDLOADLIBS=-lstdc++
-script: 
-  export BOOST_DIR=$HOME/boost
-  wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
-  perl ./Build.PL
+install: export LDLOADLIBS=-lstdc++ && export BOOST_DIR=$HOME/boost && wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && tar -xf boost_1_58_0.tar.bz2 && mv boost_1_58_0 /tmp/boost && cd /tmp/boost && ./bootstrap.sh gcc && ./b2 
+script: perl ./Build.PL
 perl:
   - "5.14"
   - "5.18"
@@ -14,6 +11,5 @@ branches:
     - stable
 sudo: false
 cache:
-    - apt
     directories:
     - /tmp/boost

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: perl
 install: 
   - export LDLOADLIBS=-lstdc++ 
-  - export BOOST_DIR=$HOME/boost 
+  - export BOOST_DIR=$HOME/boost_1_58_0 
   - wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
   - tar -xf boost_1_58_0.tar.bz2
-  - mv boost_1_58_0 $HOME/boost
-  - cd $HOME/boost
+  - cd $HOME/boost_1_58_0
   - ./bootstrap.sh gcc
   - ./b2 
 script: perl ./Build.PL
@@ -20,4 +19,4 @@ branches:
 sudo: false
 cache:
     directories:
-    - $HOME/boost
+    - $HOME/boost_1_58_0

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -53,7 +53,7 @@ my @boost_libraries = qw(system thread filesystem);  # we need these
 $have_boost = 1
     if check_lib(
         lib     => [ map "boost_${_}", @boost_libraries ],
-    ) or defined( $ENV{FORCE_BOOST});
+    );
 
 if (!$ENV{SLIC3R_STATIC} && $have_boost) {
     push @LIBS, map "-lboost_${_}", @boost_libraries;

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -53,7 +53,7 @@ my @boost_libraries = qw(system thread filesystem);  # we need these
 $have_boost = 1
     if check_lib(
         lib     => [ map "boost_${_}", @boost_libraries ],
-    );
+    ) or defined( $ENV{FORCE_BOOST});
 
 if (!$ENV{SLIC3R_STATIC} && $have_boost) {
     push @LIBS, map "-lboost_${_}", @boost_libraries;


### PR DESCRIPTION
Changes travis to use a self-hosted Boost library (1.58.0 specifically) instead of the version in Ubuntu. Working around Build.PL deciding for no reason to stop detecting Boost libs. 

This will be squash-merged in. 