### PR TITLE
Calculate actual flow for later inclusion as a ExtrusionPath for internal flow.

### DIFF
--- a/lib/Slic3r/Fill.pm
+++ b/lib/Slic3r/Fill.pm
@@ -229,6 +229,13 @@ sub make_fill {
             );
             $f->spacing($internal_flow->spacing);
             $using_internal_flow = 1;
+            # create the actual flow for internal flow that is used later.
+            $flow = Slic3r::Flow->new_from_spacing(
+                spacing         => $internal_flow->spacing,
+                nozzle_diameter => $flow->nozzle_diameter,
+                layer_height    => $h,
+                bridge          => 0,
+            );
         } else {
             $f->spacing($flow->spacing);
         }


### PR DESCRIPTION
Uses the correct layer height for the surface.

Fixes #1783 #2693 
