### PR TITLE
Moved the Bonjour discovery to Tab.pm,

### DIFF
--- a/lib/Slic3r/GUI/BonjourBrowser.pm
+++ b/lib/Slic3r/GUI/BonjourBrowser.pm
@@ -9,14 +9,10 @@ use base 'Wx::Dialog';
 
 sub new {
     my $class = shift;
-    my ($parent) = @_;
+    my ($parent, $devices) = @_;
     my $self = $class->SUPER::new($parent, -1, "Device Browser", wxDefaultPosition, [350,700], wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
     
-    # look for devices
-    eval "use Net::Bonjour; 1";
-    my $res = Net::Bonjour->new('http');
-    $res->discover;
-    $self->{devices} = [ $res->entries ];
+    $self->{devices} = $devices;
     
     # label
     my $text = Wx::StaticText->new($self, -1, "Choose an OctoPrint device in your network:", wxDefaultPosition, wxDefaultSize);

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -1132,13 +1132,24 @@ sub build {
                 }
                 
                 EVT_BUTTON($self, $btn, sub {
-                    my $dlg = Slic3r::GUI::BonjourBrowser->new($self);
-                    if ($dlg->ShowModal == wxID_OK) {
-                        my $value = $dlg->GetValue . ":" . $dlg->GetPort;
-                        $self->{config}->set('octoprint_host', $value);
-                        $self->update_dirty;
-                        $self->_on_value_change('octoprint_host', $value);
-                        $self->reload_config;
+                    # look for devices
+                    my $entries;
+                    {
+                        my $res = Net::Bonjour->new('http');
+                        $res->discover;
+                        $entries = [ $res->entries ];
+                    }
+                    if (@{$entries}) {
+                        my $dlg = Slic3r::GUI::BonjourBrowser->new($self, $entries);
+                        if ($dlg->ShowModal == wxID_OK) {
+                            my $value = $dlg->GetValue . ":" . $dlg->GetPort;
+                            $self->{config}->set('octoprint_host', $value);
+                            $self->update_dirty;
+                            $self->_on_value_change('octoprint_host', $value);
+                            $self->reload_config;
+                        }
+                    } else {
+                        Wx::MessageDialog->new($self, 'No Bonjour device found', 'Device Browser', wxOK | wxICON_INFORMATION)->ShowModal;
                     }
                 });
                 


### PR DESCRIPTION
when no Bonjour devices found, a simple message box is shown.
Otherwise the Bonjour selection dialog with an empty list crashes on windows.

Addresses #3360