### PR TITLE
New command line option: --dont-arrange #3493

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,9 @@ The author of the Silk icon set is Mark James.
         --duplicate         Number of items with auto-arrange (1+, default: 1)
         --duplicate-grid    Number of items with grid arrangement (default: 1,1)
         --duplicate-distance Distance in mm between copies (default: 6)
+        --dont-arrange      Don't arrange the objects on the build plate. The model coordinates
+                            define the absolute positions on the build plate. 
+                            The option --print-center will be ignored.
         --xy-size-compensation
                             Grow/shrink objects by the configured absolute distance (mm, default: 0)
     

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -48,6 +48,7 @@ my %cli_options = ();
         'duplicate=i'           => \$opt{duplicate},
         'duplicate-grid=s'      => \$opt{duplicate_grid},
         'print-center=s'        => \$opt{print_center},
+        'dont-arrange'          => \$opt{dont_arrange},
     );
     foreach my $opt_key (keys %{$Slic3r::Config::Options}) {
         my $cli = $Slic3r::Config::Options->{$opt_key}->{cli} or next;
@@ -204,6 +205,7 @@ if (@ARGV) {  # slicing from command line
             duplicate       => $opt{duplicate}      // 1,
             duplicate_grid  => $opt{duplicate_grid} // [1,1],
             print_center    => $opt{print_center}   // Slic3r::Pointf->new(100,100),
+            dont_arrange    => $opt{dont_arrange}   // 0,
             status_cb       => sub {
                 my ($percent, $message) = @_;
                 printf "=> %s\n", $message;
@@ -485,6 +487,9 @@ $j
     --duplicate         Number of items with auto-arrange (1+, default: 1)
     --duplicate-grid    Number of items with grid arrangement (default: 1,1)
     --duplicate-distance Distance in mm between copies (default: $config->{duplicate_distance})
+    --dont-arrange      Don't arrange the objects on the build plate. The model coordinates
+                        define the absolute positions on the build plate. 
+                        The option --print-center will be ignored.
     --xy-size-compensation
                         Grow/shrink objects by the configured absolute distance (mm, default: $config->{xy_size_compensation})
    


### PR DESCRIPTION
Don't arrange the objects on the build plate. The model coordinates
define the absolute positions on the build plate.
The option --print-center will be ignored.

Also there is a fix in the command line invocation of --duplicate-grid
so it will run, but still there is something broken there and the results
are not correct.

Provided by @bubnikv 
Fixes #3493
