### PR TITLE
Buildscripts - allow custom path for boost and detect mingw on win32

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -128,8 +128,14 @@ EOF
         
         push @cmd, "$module~$version";
         if ($module eq 'XML::SAX::ExpatXS' && $^O eq 'MSWin32') {
-            my $mingw = 'C:\dev\CitrusPerl\mingw64';
-            $mingw = 'C:\dev\CitrusPerl\mingw32' if !-d $mingw;
+            my $mingw;
+            foreach my $path (split(/;/,$ENV{'PATH'})) {
+                $path =~ s/bin$//;
+                if (-e $path . 'include\expat.h') {  # don't use -x because it fails on Windows
+                    $mingw = $path;
+                    last;
+                }
+            }            
             if (!-d $mingw) {
                 print "Could not find the MinGW directory at $mingw; skipping XML::SAX::ExpatXS (only needed for faster parsing of AMF files)\n";
             } else {

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -28,7 +28,11 @@ if (defined $ENV{BOOST_DIR}) {
     } else {
         push @boost_include, $ENV{BOOST_DIR};
     }
-    push @boost_libs, $ENV{BOOST_DIR};
+    if (-d "$ENV{BOOST_DIR}".'\\stage\lib'){
+        push @boost_libs, $ENV{BOOST_DIR} . '\\stage\lib';
+    } else{
+        push @boost_libs, $ENV{BOOST_DIR};
+    }
 } else {
     push @boost_include, grep { -d $_ }
         qw(/opt/local/include /usr/local/include /opt/include),


### PR DESCRIPTION
I have added a few lines to the build scripts to allow Win32 users to set the location of the boost libraries with a BOOST_DIR environment variable instead of forcing them to install in c:\dev. I think this is more consistent with the message generated by the build script when the libraries are not found. The second commit, still on the build scripts, is to attempt and locate Mingw by iterating through the PATH environment variable entries. MinGW should be in PATH both for Citrus and Strawberry perl, but in any case the build won't fail if it's not found, so it's more kind of a "nice to have" feature.
