### PR TITLE
Constrain OpenGL to below 0.70 to resolve segfault

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,7 +45,7 @@ if ($gui) {
     %recommends = qw(
     Growl::GNTP                     0.15
     Wx::GLCanvas                    0
-    OpenGL                          0
+    OpenGL                          <0.70
     LWP::UserAgent                  0
     Net::Bonjour                    0
     );


### PR DESCRIPTION
As reported in https://github.com/alexrj/Slic3r/issues/3540 the recently released OpenGL module version 0.70 causes segfaults on certain platforms. Restricting the module to below 0.70 resolves the issue.