### PR TITLE
3D Navigation improvement features

### DIFF
--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -148,7 +148,7 @@ sub mouse_event {
     } elsif ($e->LeftDClick) {
         $self->on_double_click->()
             if $self->on_double_click;
-    } elsif ($e->LeftDown || $e->RightDown) {
+    } elsif (($e->LeftDown || $e->RightDown) && not $e->ShiftDown) {
         # If user pressed left or right button we first check whether this happened
         # on a volume or not.
         my $volume_idx = $self->_hover_volume_idx // -1;

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -148,6 +148,14 @@ sub mouse_event {
     } elsif ($e->LeftDClick) {
         $self->on_double_click->()
             if $self->on_double_click;
+    } elsif ($e->MiddleDClick) {
+        if (@{$self->volumes}) {
+            $self->zoom_to_volumes;
+        } else {
+            $self->zoom_to_bed;
+        }
+        $self->_dirty(1);
+        $self->Refresh;
     } elsif (($e->LeftDown || $e->RightDown) && not $e->ShiftDown) {
         # If user pressed left or right button we first check whether this happened
         # on a volume or not.

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -46,6 +46,7 @@ use constant GROUND_Z       => -0.02;
 use constant DEFAULT_COLOR  => [1,1,0];
 use constant SELECTED_COLOR => [0,1,0,1];
 use constant HOVER_COLOR    => [0.4,0.9,0,1];
+use constant PI             => 3.1415927;
 
 # make OpenGL::Array thread-safe
 {
@@ -833,9 +834,44 @@ sub Render {
         glDisable(GL_BLEND);
     }
     
+    if (defined $self->_drag_start_pos || defined $self->_drag_start_xy) {
+        $self->draw_center_of_rotation($self->_camera_target->x, $self->_camera_target->y, $self->_camera_target->z);
+    }
+
     glFlush();
  
     $self->SwapBuffers();
+}
+
+sub draw_axes {
+    my ($self, $x, $y, $z, $length, $width, $allways_visible) = @_;
+    if ($allways_visible) {
+        glDisable(GL_DEPTH_TEST);
+    } else {
+        glEnable(GL_DEPTH_TEST);
+    }
+    glLineWidth($width);
+    glBegin(GL_LINES);
+    # draw line for x axis
+    glColor3f(1, 0, 0);
+    glVertex3f($x, $y, $z);
+    glVertex3f($x + $length, $y, $z);
+    # draw line for y axis
+    glColor3f(0, 1, 0);
+    glVertex3f($x, $y, $z);
+    glVertex3f($x, $y + $length, $z);
+    # draw line for Z axis
+    glColor3f(0, 0, 1);
+    glVertex3f($x, $y, $z);
+    glVertex3f($x, $y, $z + $length);
+    glEnd();
+}
+
+sub draw_center_of_rotation {
+    my ($self, $x, $y, $z) = @_;
+    
+    $self->draw_axes($x, $y, $z, 10, 1, 1);
+    $self->draw_axes($x, $y, $z, 10, 4, 0);
 }
 
 sub draw_volumes {

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -218,7 +218,16 @@ sub mouse_event {
         $self->_dragged(1);
         $self->Refresh;
     } elsif ($e->Dragging) {
-        if ($e->LeftIsDown) {
+        if ($e->AltDown) {
+            # Move the camera center on the Z axis based on mouse Y axis movement
+            if (defined $self->_drag_start_pos) {
+                my $orig = $self->_drag_start_pos;
+                $self->_camera_target->translate(0, 0, $pos->y - $orig->y);
+                $self->on_viewport_changed->() if $self->on_viewport_changed;
+                $self->Refresh;
+            }
+            $self->_drag_start_pos($pos);
+        } elsif ($e->LeftIsDown) {
             # if dragging over blank area with left button, rotate
             if (defined $self->_drag_start_pos) {
                 my $orig = $self->_drag_start_pos;


### PR DESCRIPTION
I have faced the following problems while navigating in the 3d view:

- I can only move the center of rotation on the X-Y plane so inspecting tall objects is strange.
- I cannot see the center of rotation.
- Sometimes when I want to rotate the view I accidentally move around objects, especially when zoomed in and there is not much free space in the view.
- While moving and rotating the view I have set the center of rotation far far away from the platter and cannot find it any more! Adding an object to the platter resets the view.

This PR adds the following functionality:

- Using the Alt key as modifier one can click and move the camera on the Z axis. This allows for rotating the view around any point in 3d space.
- Added a small indicator for the 3 axes that appears only when rotating or translating the view and is always positioned on the center of rotation. The axes are thin lines when they are hidden behind an object on the platter and thicker lines otherwise.

![image](https://cloud.githubusercontent.com/assets/11358178/19932613/6a66dd4a-a119-11e6-8c91-8600c7b4c41c.png)

- When the shift key is pressed while the user clicks on an object, the object is not selected and the view is allowed to rotate-translate. This allows for easier rotation of the view when zoomed in or there is too little free space on the platter.
- Double clicking the middle mouse button zooms to extents of objects, or to extents of platter when there are no objects.