### PR TITLE
Add unit test to pre-emptively check for Slic3r hangs (thanks Strawberry Perl!)

### DIFF
--- a/xs/MANIFEST
+++ b/xs/MANIFEST
@@ -121,6 +121,7 @@ t/18_motionplanner.t
 t/19_model.t
 t/20_print.t
 t/21_gcode.t
+t/22_exception.t
 xsp/BoundingBox.xsp
 xsp/BridgeDetector.xsp
 xsp/Clipper.xsp

--- a/xs/t/22_exception.t
+++ b/xs/t/22_exception.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Slic3r::XS;
+use Test::More tests => 1;
+
+{
+    eval {
+        Slic3r::xspp_test_croak_hangs_on_strawberry();
+    };
+    is $@, "xspp_test_croak_hangs_on_strawberry: exception catched\n", 'croak from inside a C++ exception delivered';
+}
+
+__END__

--- a/xs/xsp/XS.xsp
+++ b/xs/xsp/XS.xsp
@@ -16,4 +16,24 @@ VERSION()
         RETVAL = newSVpv(SLIC3R_VERSION, 0);
     OUTPUT: RETVAL
 
+SV*
+DEBUG_OUT_PATH_PREFIX()
+    CODE:
+        RETVAL = newSVpv(SLIC3R_DEBUG_OUT_PATH_PREFIX, 0);
+    OUTPUT: RETVAL
+
+SV*
+FORK_NAME()
+    CODE:
+        RETVAL = newSVpv(SLIC3R_FORK_NAME, 0);
+    OUTPUT: RETVAL
+
+void
+xspp_test_croak_hangs_on_strawberry()
+    CODE:
+    	try {
+    		throw 1;
+    	} catch (...) {
+    		croak("xspp_test_croak_hangs_on_strawberry: exception catched\n");
+    	}
 %}

--- a/xs/xsp/XS.xsp
+++ b/xs/xsp/XS.xsp
@@ -16,18 +16,6 @@ VERSION()
         RETVAL = newSVpv(SLIC3R_VERSION, 0);
     OUTPUT: RETVAL
 
-SV*
-DEBUG_OUT_PATH_PREFIX()
-    CODE:
-        RETVAL = newSVpv(SLIC3R_DEBUG_OUT_PATH_PREFIX, 0);
-    OUTPUT: RETVAL
-
-SV*
-FORK_NAME()
-    CODE:
-        RETVAL = newSVpv(SLIC3R_FORK_NAME, 0);
-    OUTPUT: RETVAL
-
 void
 xspp_test_croak_hangs_on_strawberry()
     CODE:


### PR DESCRIPTION
Unit test to verify whether Slic3r would hang when croaking from a C++ exception handler. This is an unfortunate error in some Strawberry Perl distributions.

Provided by @bubnikv 