### PR TITLE
Set the tooltip display timer to the max accepted value

### DIFF
--- a/lib/Slic3r/GUI/MainFrame.pm
+++ b/lib/Slic3r/GUI/MainFrame.pm
@@ -33,6 +33,10 @@ sub new {
     $self->_init_tabpanel;
     $self->_init_menubar;
     
+    # set default tooltip timer in msec
+    # SetAutoPop supposedly accepts long integers but some bug doesn't allow for larger values
+    Wx::ToolTip::SetAutoPop(32767);
+    
     # initialize status bar
     $self->{statusbar} = Slic3r::GUI::ProgressStatusBar->new($self, -1);
     $self->{statusbar}->SetStatusText("Version $Slic3r::VERSION - Remember to check for updates at http://slic3r.org/");


### PR DESCRIPTION
Fix for #3116 , probably the first issue I also had with Slic3r when learning the settings!
`Wx::ToolTip::SetAutoPop()`  is supposed to accept long integer values in milliseconds, though some bug doesn't allow long values, so the biggest int is entered that makes tooltips dissapear after 32 seconds.
I couldn't find a more appropriate place to enter the code, so I entered it in MainFrame.pm
