### PR TITLE
Fixed a bug with the "Window" menu items.

### DIFF
--- a/lib/Slic3r/GUI/MainFrame.pm
+++ b/lib/Slic3r/GUI/MainFrame.pm
@@ -98,9 +98,9 @@ sub _init_tabpanel {
     
     if (!$self->{no_plater}) {
         $panel->AddPage($self->{plater} = Slic3r::GUI::Plater->new($panel), "Plater");
-        if (!$self->{no_controller}) {
-            $panel->AddPage($self->{controller} = Slic3r::GUI::Controller->new($panel), "Controller");
-        }
+    }
+    if (!$self->{no_controller}) {
+        $panel->AddPage($self->{controller} = Slic3r::GUI::Controller->new($panel), "Controller");
     }
     $self->{options_tabs} = {};
     
@@ -254,14 +254,18 @@ sub _init_menubar {
             $self->_append_menu_item($windowMenu, "Select &Plater Tab\tCtrl+1", 'Show the plater', sub {
                 $self->select_tab(0);
             }, undef, 'application_view_tile.png');
-            if (!$self->{no_controller}) {
-                $self->_append_menu_item($windowMenu, "Select &Controller Tab\tCtrl+T", 'Show the printer controller', sub {
-                    $self->select_tab(1);
-                }, undef, 'printer_empty.png');
-            }
-            $windowMenu->AppendSeparator();
-            $tab_offset += 2;
+            $tab_offset += 1;
         }
+        if (!$self->{no_controller}) {
+            $self->_append_menu_item($windowMenu, "Select &Controller Tab\tCtrl+T", 'Show the printer controller', sub {
+                $self->select_tab(1);
+            }, undef, 'printer_empty.png');
+            $tab_offset += 1;
+        }
+        if ($tab_offset > 0) {
+            $windowMenu->AppendSeparator();
+        }
+        
         $self->_append_menu_item($windowMenu, "Select P&rint Settings Tab\tCtrl+2", 'Show the print settings', sub {
             $self->select_tab($tab_offset+0);
         }, undef, 'cog.png');


### PR DESCRIPTION
If the "Controller" tab was not visible (disabled from preferences), then the menu items and their shortcuts opened the wrong tab.
Also, the controller tab was not visible if the plater tab was not visible too.