### PR TITLE
Quick compile fixes

### DIFF
--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -15,7 +15,7 @@ my $mswin = $^O eq 'MSWin32';
 # HAS_BOOL         : stops Perl/lib/CORE/handy.h from doing "#  define bool char" for MSVC
 # NOGDI            : prevents inclusion of wingdi.h which defines functions Polygon() and Polyline() in global namespace
 # BOOST_ASIO_DISABLE_KQUEUE : prevents a Boost ASIO bug on OS X: https://svn.boost.org/trac/boost/ticket/5339
-my @cflags = qw(-D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
+my @cflags = qw(--std=c++11 -D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
 my @ldflags = ();
 if ($^O eq 'darwin') {
     push @ldflags, qw(-framework IOKit -framework CoreFoundation);

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -50,7 +50,7 @@ TriangleMesh::TriangleMesh(const TriangleMesh &other)
 
 TriangleMesh& TriangleMesh::operator= (TriangleMesh other)
 {
-    swap(*this, other);
+    this->swap(other);
     return *this;
 }
 


### PR DESCRIPTION
Two fixes to allow libslic3r to compile under windows.

1) GCC wants a flag to indicate that c++11 is in use, or else it complains loudly about the use of static_assert().

2) gcc 4.9.2 can't find TriangleMesh::swap with both hands and a radio telescope. Added an explicit reference so it knows where to go.