### PR TITLE
Avoid recentering viewport if the bounding box is max size 0

### DIFF
--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -370,12 +370,15 @@ sub zoom_to_bounding_box {
     # bounding box
     my $max_size = max(@{$bb->size}) * 2;
     my $min_viewport_size = min($self->GetSizeWH);
-    $self->_zoom($min_viewport_size / $max_size);
+    if ($max_size != 0) {
+        # only re-zoom if we have a valid bounding box, avoid a divide by 0 error.
+        $self->_zoom($min_viewport_size / $max_size);
     
-    # center view around bounding box center
-    $self->_camera_target($bb->center);
+        # center view around bounding box center
+        $self->_camera_target($bb->center);
     
-    $self->on_viewport_changed->() if $self->on_viewport_changed;
+        $self->on_viewport_changed->() if $self->on_viewport_changed;
+    }
 }
 
 sub zoom_to_bed {


### PR DESCRIPTION
Defensive coding - fix provided by @jreinam

Fixes #3589 