### PR TITLE
Fix perl redefining multiple functions used by boost

### DIFF
--- a/xs/src/xsinit.h
+++ b/xs/src/xsinit.h
@@ -31,6 +31,7 @@
 #include <ostream>
 #include <iostream>
 #include <sstream>
+#include <libslic3r.h>
 
 #ifdef SLIC3RXS
 extern "C" {
@@ -50,7 +51,6 @@ extern "C" {
 }
 #endif
 
-#include <libslic3r.h>
 #include <ClipperUtils.hpp>
 #include <Config.hpp>
 #include <ExPolygon.hpp>


### PR DESCRIPTION
Should fix remaining compile issues on Windows.

Fixes #3583