### PR TITLE
Retract when there is no a lower layer, like in the first layer.

### DIFF
--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -666,7 +666,9 @@ GCode::needs_retraction(const Polyline &travel, ExtrusionRole role)
         }
     }
     
-    if (this->config.only_retract_when_crossing_perimeters && this->layer != NULL) {
+    if (this->config.only_retract_when_crossing_perimeters
+        && this->layer != NULL
+        && this->layer->lower_layer != NULL) {
         if (this->config.fill_density.value > 0
             && this->layer->any_internal_region_slice_contains(travel)) {
             /*  skip retraction if travel is contained in an internal slice *and*


### PR DESCRIPTION
Not sure if this small addition is all the code needed to fix #3053, but it seems to work.