### PR TITLE
Use --local-lib when calling cpanm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ MANIFEST.bak
 xs/MANIFEST.bak
 xs/assertlib*
 .init_bundle.ini
+local-lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ addons:
     - libboost-thread1.55-dev
     - libboost-system1.55-dev
     - libboost-filesystem1.55-dev
+    - liblocal-lib-perl

--- a/Build.PL
+++ b/Build.PL
@@ -107,7 +107,16 @@ EOF
         if !$cpanm;
     my @cpanm_args = ();
     push @cpanm_args, "--sudo" if $sudo;
-
+    
+    # install local::lib without --local-lib otherwise it's not usable afterwards
+    if (!eval "use local::lib; 1") {
+        my $res = system $cpanm, @cpanm_args, 'local::lib';
+        warn "Warning: local::lib is required. You might need to run the `cpanm --sudo local::lib` command in order to install it.\n"
+            if $res != 0;
+    }
+    
+    push @cpanm_args, ('--local-lib', 'local-lib');
+    
     # make sure our cpanm is updated (old ones don't support the ~ syntax)
     system $cpanm, @cpanm_args, 'App::cpanminus';
     

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -6,6 +6,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/lib";
+    use local::lib "$FindBin::Bin/local-lib";
 }
 
 use File::Basename qw(basename);

--- a/t/angles.t
+++ b/t/angles.t
@@ -7,6 +7,9 @@ plan tests => 34;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use lib "$FindBin::Bin/../lib";
+    use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/arcs.t
+++ b/t/arcs.t
@@ -7,6 +7,7 @@ plan tests => 24;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/avoid_crossing_perimeters.t
+++ b/t/avoid_crossing_perimeters.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first sum);

--- a/t/bridges.t
+++ b/t/bridges.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first sum);

--- a/t/clean_polylines.t
+++ b/t/clean_polylines.t
@@ -7,6 +7,7 @@ plan tests => 6;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/clipper.t
+++ b/t/clipper.t
@@ -7,6 +7,7 @@ plan tests => 6;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(sum);

--- a/t/collinear.t
+++ b/t/collinear.t
@@ -7,6 +7,7 @@ plan tests => 11;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/combineinfill.t
+++ b/t/combineinfill.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/config.t
+++ b/t/config.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/cooling.t
+++ b/t/cooling.t
@@ -7,6 +7,7 @@ plan tests => 12;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/custom_gcode.t
+++ b/t/custom_gcode.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/dynamic.t
+++ b/t/dynamic.t
@@ -8,6 +8,7 @@ plan tests => 20;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/fill.t
+++ b/t/fill.t
@@ -7,6 +7,7 @@ plan tests => 92;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first sum);

--- a/t/flow.t
+++ b/t/flow.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first sum);

--- a/t/gaps.t
+++ b/t/gaps.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/gcode.t
+++ b/t/gcode.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/geometry.t
+++ b/t/geometry.t
@@ -7,6 +7,7 @@ plan tests => 42;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/layers.t
+++ b/t/layers.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/loops.t
+++ b/t/loops.t
@@ -8,6 +8,7 @@ plan tests => 4;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/multi.t
+++ b/t/multi.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/perimeters.t
+++ b/t/perimeters.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r::ExtrusionLoop ':roles';

--- a/t/polyclip.t
+++ b/t/polyclip.t
@@ -7,6 +7,7 @@ plan tests => 18;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/pressure.t
+++ b/t/pressure.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw();

--- a/t/print.t
+++ b/t/print.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/retraction.t
+++ b/t/retraction.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(any);

--- a/t/shells.t
+++ b/t/shells.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first sum);

--- a/t/skirt_brim.t
+++ b/t/skirt_brim.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/slice.t
+++ b/t/slice.t
@@ -8,6 +8,7 @@ plan tests => 16;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 # temporarily disable compilation errors due to constant not being exported anymore

--- a/t/support.t
+++ b/t/support.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/svg.t
+++ b/t/svg.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/thin.t
+++ b/t/thin.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/t/threads.t
+++ b/t/threads.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use List::Util qw(first);

--- a/t/vibrationlimit.t
+++ b/t/vibrationlimit.t
@@ -5,6 +5,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/utils/amf-to-stl.pl
+++ b/utils/amf-to-stl.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use File::Basename qw(basename);

--- a/utils/config-bundle-to-config.pl
+++ b/utils/config-bundle-to-config.pl
@@ -9,6 +9,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);

--- a/utils/dump-stl.pl
+++ b/utils/dump-stl.pl
@@ -8,6 +8,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/utils/gcode_sectioncut.pl
+++ b/utils/gcode_sectioncut.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);

--- a/utils/pdf-slices.pl
+++ b/utils/pdf-slices.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);

--- a/utils/send-gcode.pl
+++ b/utils/send-gcode.pl
@@ -6,6 +6,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Slic3r;

--- a/utils/split_stl.pl
+++ b/utils/split_stl.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use File::Basename qw(basename);

--- a/utils/stl-to-amf.pl
+++ b/utils/stl-to-amf.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use File::Basename qw(basename);

--- a/utils/view-mesh.pl
+++ b/utils/view-mesh.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);

--- a/utils/view-toolpaths.pl
+++ b/utils/view-toolpaths.pl
@@ -7,6 +7,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);

--- a/utils/wireframe.pl
+++ b/utils/wireframe.pl
@@ -8,6 +8,7 @@ use warnings;
 BEGIN {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
+    use local::lib "$FindBin::Bin/../local-lib";
 }
 
 use Getopt::Long qw(:config no_auto_abbrev);


### PR DESCRIPTION
I propose to supply `--local-lib local-lib` to cpanm so that every module is installed in the local-lib directory. Advantages of this:

* no more need to tell users to install and initialize local::lib themselves
* no more need for `sudo`
* easier troubleshooting for users here, no more permission issues
* ability to keep several Slic3r versions or branches (instead of recompiling every time I switch between branches)

@lordofhyphens, what do you think?
I'm sure @henrikbrixandersen would appreciate this :-)