### PR TITLE
Minor revisions/updates for win32 packager

### DIFF
--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -13,8 +13,14 @@ New-Variable -Name "current_date" -Value "$(Get-Date -UFormat '%Y.%m.%d')"
 New-Variable -Name "output_file" -Value ""
 
 git branch | foreach {
-   if ($_ -match "\*` (.*)"){
-         $current_branch += $matches[1]
+   if (Test-Path variable:\APPVEYOR_BUILD_NUMBER) {
+	   if ($_ -match "` (.*)"){
+		   $current_branch += $matches[1]
+	   }
+   } else {
+	   if ($_ -match "\*` (.*)"){
+		   $current_branch += $matches[1]
+	   }
    }
 }
 if ($exe) {
@@ -139,7 +145,7 @@ if ($exe) {
 } else {
 # make this more useful for not being on the appveyor server
 	if (Test-Path variable:\APPVEYOR_BUILD_NUMBER) {
-		copy ..\slic3r.par "..\slic3r-${current_branch}-${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
+		copy ..\slic3r.par "..\slic3r-${current_branch}-$(current_date).${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
 	} else {
 		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).zip"
 			del ../slic3r.par

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -13,7 +13,7 @@ New-Variable -Name "current_date" -Value "$(Get-Date -UFormat '%Y.%m.%d')"
 New-Variable -Name "output_file" -Value ""
 
 git branch | foreach {
-   if (Test-Path variable:\APPVEYOR_BUILD_NUMBER) {
+   if ($APPVEYOR) {
 	   if ($_ -match "` (.*)"){
 		   $current_branch += $matches[1]
 	   }
@@ -135,7 +135,7 @@ pp `
 
 # switch renaming based on whether or not using packaged exe or zip 
 if ($exe) {
-	if (Test-Path variable:\APPVEYOR_BUILD_NUMBER) {
+	if ($APPVEYOR) {
 		copy ..\slic3r.exe "..\slic3r-${current_branch}-${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).exe"
 		del ..\slic3r.exe
 	} else {
@@ -144,7 +144,7 @@ if ($exe) {
 	}
 } else {
 # make this more useful for not being on the appveyor server
-	if (Test-Path variable:\APPVEYOR_BUILD_NUMBER) {
+	if ($APPVEYOR) {
 		copy ..\slic3r.par "..\slic3r-${current_branch}-$(current_date).${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
 	} else {
 		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).zip"

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -13,7 +13,7 @@ New-Variable -Name "current_date" -Value "$(Get-Date -UFormat '%Y.%m.%d')"
 New-Variable -Name "output_file" -Value ""
 
 git branch | foreach {
-   if ($APPVEYOR) {
+   if ($env:APPVEYOR) {
 	   if ($_ -match "` (.*)"){
 		   $current_branch += $matches[1]
 	   }
@@ -135,8 +135,8 @@ pp `
 
 # switch renaming based on whether or not using packaged exe or zip 
 if ($exe) {
-	if ($APPVEYOR) {
-		copy ..\slic3r.exe "..\slic3r-${current_branch}-${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).exe"
+	if ($env:APPVEYOR) {
+		copy ..\slic3r.exe "..\slic3r-${current_branch}-${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).exe"
 		del ..\slic3r.exe
 	} else {
 		copy ..\slic3r.exe "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).exe"
@@ -144,8 +144,8 @@ if ($exe) {
 	}
 } else {
 # make this more useful for not being on the appveyor server
-	if ($APPVEYOR) {
-		copy ..\slic3r.par "..\slic3r-${current_branch}-$(current_date).${APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
+	if ($env:APPVEYOR) {
+		copy ..\slic3r.par "..\slic3r-${current_branch}-$(current_date).${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
 	} else {
 		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).zip"
 			del ../slic3r.par

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -136,7 +136,7 @@ pp `
 # switch renaming based on whether or not using packaged exe or zip 
 if ($exe) {
 	if ($env:APPVEYOR) {
-		copy ..\slic3r.exe "..\slic3r-${current_branch}-${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).exe"
+		copy ..\slic3r.exe "..\slic3r-${current_branch}.${current_date}.${env:APPVEYOR_BUILD_NUMBER}.$(git rev-parse --short HEAD).exe"
 		del ..\slic3r.exe
 	} else {
 		copy ..\slic3r.exe "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).exe"
@@ -145,7 +145,7 @@ if ($exe) {
 } else {
 # make this more useful for not being on the appveyor server
 	if ($env:APPVEYOR) {
-		copy ..\slic3r.par "..\slic3r-${current_branch}-${current_date}.${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
+		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.${env:APPVEYOR_BUILD_NUMBER}.$(git rev-parse --short HEAD).zip"
 	} else {
 		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).zip"
 			del ../slic3r.par

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -14,7 +14,7 @@ New-Variable -Name "output_file" -Value ""
 
 git branch | foreach {
    if ($env:APPVEYOR) {
-	   if ($_ -match "`  (.*)")
+	   if ($_ -match "`  (.*)") {
 		   $current_branch += $matches[1]
 	   }
    } else {

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -145,7 +145,7 @@ if ($exe) {
 } else {
 # make this more useful for not being on the appveyor server
 	if ($env:APPVEYOR) {
-		copy ..\slic3r.par "..\slic3r-${current_branch}-$(current_date).${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
+		copy ..\slic3r.par "..\slic3r-${current_branch}-${current_date}.${env:APPVEYOR_BUILD_NUMBER}-$(git rev-parse --short HEAD).zip"
 	} else {
 		copy ..\slic3r.par "..\slic3r-${current_branch}.${current_date}.$(git rev-parse --short HEAD).zip"
 			del ../slic3r.par

--- a/utils/package_win32.ps1
+++ b/utils/package_win32.ps1
@@ -14,7 +14,7 @@ New-Variable -Name "output_file" -Value ""
 
 git branch | foreach {
    if ($env:APPVEYOR) {
-	   if ($_ -match "` (.*)"){
+	   if ($_ -match "`  (.*)")
 		   $current_branch += $matches[1]
 	   }
    } else {


### PR DESCRIPTION
fixes the naming scheme for the packager for the Appveyor build environment (which apparently needs a slightly different regex)

Fixes #3633