### PR TITLE
Disable background processing by default.

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -67,7 +67,7 @@ our $Settings = {
         mode => 'simple',
         version_check => 1,
         autocenter => 1,
-        background_processing => 1,
+        background_processing => 0,
         # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
         # By default, Prusa has the controller hidden.
         no_controller => 1,


### PR DESCRIPTION
It causes more problems than it solves, especially with the new slice-on-preview code available.

Most of the weird crash bugs in Slic3r can usually be traced to background processing and strange timing issues that are very very difficult to reproduce. 