### PR TITLE
Fixed a bug in renaming a G-code at the end of a G-code export

### DIFF
--- a/lib/Slic3r/Print.pm
+++ b/lib/Slic3r/Print.pm
@@ -101,7 +101,7 @@ sub export_gcode {
 
         # close our gcode file
         close $fh;
-        rename $tempfile, $output_file if $tempfile;
+        rename Slic3r::encode_path($tempfile), Slic3r::encode_path($output_file) if $tempfile;
     }
     
     # run post-processing scripts


### PR DESCRIPTION
from .tmp suffix to a non .tmp file on localized Windows, thanks @bubnikv