### PR TITLE
Added windows shell and script

### DIFF
--- a/package/win/compile_wrapper.ps1
+++ b/package/win/compile_wrapper.ps1
@@ -1,0 +1,7 @@
+# Short Powershell script to build a wrapper exec
+
+$perlver = $args[0] 
+$perllib = "-lperl$perlver"
+Write-Host $perllib
+
+g++ -I'C:\strawberry\perl\lib\CORE\' $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe

--- a/package/win/compile_wrapper.ps1
+++ b/package/win/compile_wrapper.ps1
@@ -1,7 +1,14 @@
 # Short Powershell script to build a wrapper exec
+if ($args[0])
+{
+	$perlver = $args[0]
+} else 
+{
+	$perlver = 518
+}
 
-$perlver = $args[0] 
 $perllib = "-lperl$perlver"
 Write-Host $perllib
 
-g++ -v -I'C:\strawberry\perl\lib\CORE\' -static-libgcc -static-libstdc++ $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe | Write-Host
+g++ -v -I'C:\strawberry\perl\lib\CORE\' -static-libgcc -static-libstdc++ -L'C:\strawberry\c\lib' -L'C:\strawberry\perl\bin' -L'C:\strawberry\perl\lib\CORE\' $perllib .\shell.cpp -o slic3r.exe | Write-Host
+

--- a/package/win/compile_wrapper.ps1
+++ b/package/win/compile_wrapper.ps1
@@ -8,7 +8,8 @@ if ($args[0])
 }
 
 $perllib = "-lperl$perlver"
-Write-Host $perllib
 
-g++ -v -I'C:\strawberry\perl\lib\CORE\' -static-libgcc -static-libstdc++ -L'C:\strawberry\c\lib' -L'C:\strawberry\perl\bin' -L'C:\strawberry\perl\lib\CORE\' $perllib .\shell.cpp -o slic3r.exe | Write-Host
+windres slic3r.rc -O coff -o slic3r.res
+g++ -c -I'C:\strawberry\perl\lib\CORE\' shell.cpp -o slic3r.o
+g++ -v -static-libgcc -static-libstdc++ -L'C:\strawberry\c\lib' -L'C:\strawberry\perl\bin' -L'C:\strawberry\perl\lib\CORE\' $perllib slic3r.o slic3r.res -o slic3r.exe | Write-Host
 

--- a/package/win/compile_wrapper.ps1
+++ b/package/win/compile_wrapper.ps1
@@ -4,4 +4,4 @@ $perlver = $args[0]
 $perllib = "-lperl$perlver"
 Write-Host $perllib
 
-g++ -I'C:\strawberry\perl\lib\CORE\' $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe
+g++ -v -I'C:\strawberry\perl\lib\CORE\' $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe | Write-Host

--- a/package/win/compile_wrapper.ps1
+++ b/package/win/compile_wrapper.ps1
@@ -4,4 +4,4 @@ $perlver = $args[0]
 $perllib = "-lperl$perlver"
 Write-Host $perllib
 
-g++ -v -I'C:\strawberry\perl\lib\CORE\' $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe | Write-Host
+g++ -v -I'C:\strawberry\perl\lib\CORE\' -static-libgcc -static-libstdc++ $perllib -L'C:\strawberry\perl\bin\'  .\shell.cpp -o slic3r.exe | Write-Host

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -58,8 +58,6 @@ pp `
 -M B `
 -M Carp `
 -M Class::Accessor `
--M Class::XSAccessor `
--M Class::XSAccessor::Heavy `
 -M Config `
 -M Crypt::CBC `
 -M Cwd `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -54,6 +54,7 @@ pp `
 -a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
 -a "${STRAWBERRY_PATH}\perl\bin\libgcc_s_sjlj-1.dll;libgcc_s_sjlj-1.dll"  `
 -a "${STRAWBERRY_PATH}\c\bin\pthreadGC2-w64.dll;pthreadGC2-w64.dll"  `
+-a "${STRAWBERRY_PATH}\c\bin\libglut-0__.dll;libglut-0__.dll"  `
 -M AutoLoader `
 -M B `
 -M Carp `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -52,7 +52,7 @@ pp `
 -a "../../FreeGLUT/freeglut.dll;freeglut.dll" `
 -a "${STRAWBERRY_PATH}\perl\bin\perl${perlversion}.dll;perl${perlversion}.dll"  `
 -a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\pthreadGC2-w64.dll;pthreadGC2-w64.dll"  `
+-a "${STRAWBERRY_PATH}\c\bin\pthreadGC2-w64.dll;pthreadGC2-w64.dll"  `
 -M AutoLoader `
 -M B `
 -M Carp `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -52,8 +52,7 @@ pp `
 -a "../../FreeGLUT/freeglut.dll;freeglut.dll" `
 -a "${STRAWBERRY_PATH}\perl\bin\perl${perlversion}.dll;perl${perlversion}.dll"  `
 -a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\libwinpthread-1.dll;libwinpthread-1.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\freeglut.dll;freeglut.dll"  `
+-a "${STRAWBERRY_PATH}\perl\bin\pthreadGC2-w64.dll;pthreadGC2-w64.dll"  `
 -M AutoLoader `
 -M B `
 -M Carp `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -52,6 +52,7 @@ pp `
 -a "../../FreeGLUT/freeglut.dll;freeglut.dll" `
 -a "${STRAWBERRY_PATH}\perl\bin\perl${perlversion}.dll;perl${perlversion}.dll"  `
 -a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
+-a "${STRAWBERRY_PATH}\perl\bin\libgcc_s_sjlj-1.dll;libgcc_s_sjlj-1.dll"  `
 -a "${STRAWBERRY_PATH}\c\bin\pthreadGC2-w64.dll;pthreadGC2-w64.dll"  `
 -M AutoLoader `
 -M B `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -127,6 +127,7 @@ pp `
 -M URI::Escape `
 -M URI::http `
 -M Unicode::Normalize `
+-M Win32 `
 -M Win32::API `
 -M Win32::TieRegistry `
 -M Win32::WinError `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -12,6 +12,14 @@ New-Variable -Name "current_branch" -Value ""
 New-Variable -Name "current_date" -Value "$(Get-Date -UFormat '%Y.%m.%d')"
 New-Variable -Name "output_file" -Value ""
 
+if ($args[0]) {
+	$perlversion = $args[0]
+} else {
+	$perlversion = "524"
+}
+
+$perldll = "perl$perlversion"
+
 git branch | foreach {
    if ($env:APPVEYOR) {
 	   if ($_ -match "`  (.*)") {
@@ -35,19 +43,17 @@ New-Variable -Name "STRAWBERRY_PATH" -Value "C:\Strawberry"
 cpanm "PAR::Packer"
 
 pp `
--a "../../utils;utils"  `
--a "autorun.bat;slic3r.bat"  `
--a "../../var;var"  `
--a "${STRAWBERRY_PATH}\perl\bin\perl5.24.0.exe;perl5.24.0.exe"  `
--a "${STRAWBERRY_PATH}\perl\bin\perl524.dll;perl524.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\libgcc_s_sjlj-1.dll;libgcc_s_sjlj-1.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\libwinpthread-1.dll;libwinpthread-1.dll"  `
--a "${STRAWBERRY_PATH}\perl\bin\freeglut.dll;freeglut.dll"  `
--a "${STRAWBERRY_PATH}\c\bin\libglut-0_.dll;libglut-0_.dll"  `
+-a "slic3r.exe;slic3r.exe"  `
 -a "../../lib;lib" `
 -a "../../local-lib;local-lib" `
 -a "../../slic3r.pl;slic3r.pl" `
+-a "../../utils;utils"  `
+-a "../../var;var"  `
+-a "../../FreeGLUT/freeglut.dll;freeglut.dll" `
+-a "${STRAWBERRY_PATH}\perl\bin\perl${perlversion}.dll;perl${perlversion}.dll"  `
+-a "${STRAWBERRY_PATH}\perl\bin\libstdc++-6.dll;libstdc++-6.dll"  `
+-a "${STRAWBERRY_PATH}\perl\bin\libwinpthread-1.dll;libwinpthread-1.dll"  `
+-a "${STRAWBERRY_PATH}\perl\bin\freeglut.dll;freeglut.dll"  `
 -M AutoLoader `
 -M B `
 -M Carp `

--- a/package/win/package_win32.ps1
+++ b/package/win/package_win32.ps1
@@ -113,7 +113,6 @@ pp `
 -M Sub::Exporter `
 -M Sub::Exporter::Progressive `
 -M Sub::Name `
--M Sub::Util `
 -M Symbol `
 -M Term::Cap `
 -M Text::ParseWords `

--- a/package/win/shell.cpp
+++ b/package/win/shell.cpp
@@ -1,0 +1,84 @@
+#include <EXTERN.h> // from the Perl distribution
+#include <perl.h> // from the Perl distribution
+
+// Perl win32 specific includes, found in perl\\lib\\CORE\\win32.h
+// Defines the windows specific convenience RunPerl() function,
+// which is not available on other operating systems.
+#include <win32.h>
+// the standard Windows. include
+//#include <Windows.h>
+#include <cstdio>
+#include <cstdlib>
+#include <wchar.h>
+
+int main(int argc, char **argv, char **env)
+{
+	
+	// replaces following Windows batch file: @"%~dp0\perl5.24.0.exe"
+	// "%~dp0\slic3r.pl" --DataDir "C:\Users\Public\Documents\Prusa3D\Slic3r
+	// settings MK2"%*
+
+	// If the Slic3r is installed in a localized directory (containing non-iso
+	// characters), spaces or semicolons, use short file names.
+
+	char    exe_path[MAX_PATH] = {0};
+	char    script_path[MAX_PATH];
+	char**  command_line = (char**)malloc(sizeof(char*) * ((++ argc) + 1));
+	{
+		// Unicode path. This will not be used directly, but to test, whether
+		// there are any non-ISO characters, in which case the path is converted to a
+		// short path (using 8.3 directory names).
+
+		wchar_t exe_path_w[MAX_PATH] = {0};
+		char    drive[_MAX_DRIVE];
+		char    dir[_MAX_DIR];
+		char    fname[_MAX_FNAME];
+		char    ext[_MAX_EXT];
+		bool    needs_short_paths = false;
+		int     len;
+		int     i;
+		GetModuleFileNameA(NULL, exe_path, MAX_PATH-1);
+		GetModuleFileNameW(NULL, exe_path_w, MAX_PATH-1);
+		len = strlen(exe_path);
+
+		if (len != wcslen(exe_path_w)) {
+			needs_short_paths = true;
+		} else {
+			for (i = 0; i < len; ++ i)
+				if ((wchar_t)exe_path[i] != exe_path_w[i] || exe_path[i] == ' ' ||
+						exe_path[i] == ';') {
+					needs_short_paths = true;
+					break;
+				}
+		}
+		if (needs_short_paths) {
+			wchar_t exe_path_short[MAX_PATH] = {0};
+			GetShortPathNameW(exe_path_w, exe_path_short, MAX_PATH);
+			len = wcslen(exe_path_short);
+			for (i = 0; i <= len; ++ i)
+				exe_path[i] = (char)exe_path_short[i];
+		}
+		_splitpath(exe_path, drive, dir, fname, ext);
+		_makepath(script_path, drive, dir, NULL, NULL);
+		if (needs_short_paths)
+			printf("Slic3r installed in a loclized path. Using an 8.3 path: \"%s\"\n",
+					script_path);
+		SetDllDirectoryA(script_path);
+		_makepath(script_path, drive, dir, "slic3r", "pl");
+		command_line[0] = exe_path;
+		command_line[1] = script_path;
+		memcpy(command_line + 2, argv + 1, sizeof(char*) * (argc - 2));
+		command_line[argc] = NULL;
+		// Unset the PERL5LIB and PERLLIB environment variables.
+		SetEnvironmentVariable("PERL5LIB", NULL);
+		SetEnvironmentVariable("PERLLIB", NULL);
+#if 0
+		printf("Arguments: \r\n");
+		for (size_t i = 0; i < argc + 1; ++ i)
+			printf(" %d: %s\r\n", i, command_line[i]);
+#endif
+	}
+	RunPerl(argc, command_line, NULL);
+	free(command_line);
+}
+

--- a/package/win/slic3r.rc
+++ b/package/win/slic3r.rc
@@ -1,0 +1,25 @@
+id ICON "../../var/Slic3r.ico"
+1 VERSIONINFO
+FILEVERSION     1,3,0,0
+PRODUCTVERSION  1,3,0,0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "CompanyName", "Slic3r.org"
+      VALUE "FileDescription", "3D Printer Slicer application"
+      VALUE "FileVersion", "1.3.0"
+      VALUE "InternalName", "slic3r"
+      VALUE "LegalCopyright", "Alessandro Ranellucci"
+      VALUE "OriginalFilename", "slic3r.exe"
+      VALUE "ProductName", "Slic3r"
+      VALUE "ProductVersion", "1.3.0"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1252
+  END
+END
+


### PR DESCRIPTION
Original shell courtesy of @bubnikv. 

This will be merged after I get the build server behaving itself (using perl 5.18-x64 instead of 5.24-x32).

Slic3r dependency archive (x64) -- all of the Perl modules needed to build Slic3r in one handy archive.
https://bintray.com/lordofhyphens/Slic3r/download_file?file_path=slic3r-perl-dependencies-5.18.0-win-x64.7z