### PR TITLE
Add option to specify infill/perimeter overlay for bridge areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ The author of the Silk icon set is Mark James.
         --support-material-extrusion-width
                             Set a different extrusion width for support material
         --infill-overlap    Overlap between infill and perimeters (default: 15%)
+        --bridge-infill-overlap
+                            Overlap between bridge infill and perimeters (default: 15%)
         --bridge-flow-ratio Multiplier for extrusion when bridging (> 0, default: 1)
     
        Multiple extruder options:

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -496,7 +496,7 @@ sub build {
         extrusion_width first_layer_extrusion_width perimeter_extrusion_width 
         external_perimeter_extrusion_width infill_extrusion_width solid_infill_extrusion_width 
         top_infill_extrusion_width support_material_extrusion_width
-        infill_overlap bridge_flow_ratio
+        infill_overlap bridge_infill_overlap bridge_flow_ratio
         xy_size_compensation threads resolution
     ));
     $self->{config}->set('print_settings_id', '');
@@ -676,6 +676,7 @@ sub build {
         {
             my $optgroup = $page->new_optgroup('Overlap');
             $optgroup->append_single_option_line('infill_overlap');
+            $optgroup->append_single_option_line('bridge_infill_overlap');
         }
         {
             my $optgroup = $page->new_optgroup('Flow');

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -570,6 +570,8 @@ $j
     --support-material-extrusion-width
                         Set a different extrusion width for support material
     --infill-overlap    Overlap between infill and perimeters (default: $config->{infill_overlap})
+    --bridge-infill-overlap
+                        Overlap between bridge infill and perimeters (default: $config->{bridge_infill_overlap})
     --bridge-flow-ratio Multiplier for extrusion when bridging (> 0, default: $config->{bridge_flow_ratio})
   
    Multiple extruder options:

--- a/xs/src/libslic3r/LayerRegionFill.cpp
+++ b/xs/src/libslic3r/LayerRegionFill.cpp
@@ -226,8 +226,13 @@ LayerRegion::make_fill()
             f->min_spacing = flow.spacing();
         }
         
-        f->endpoints_overlap = this->region()->config.get_abs_value("infill_overlap",
-            (perimeter_spacing + scale_(f->min_spacing))/2);
+        if (is_bridge) {
+            f->endpoints_overlap = this->region()->config.get_abs_value("bridge_infill_overlap",
+                (perimeter_spacing + scale_(f->min_spacing))/2);
+        } else {
+            f->endpoints_overlap = this->region()->config.get_abs_value("infill_overlap",
+                (perimeter_spacing + scale_(f->min_spacing))/2);
+        }
 
         f->layer_id = this->layer()->id();
         f->z        = this->layer()->print_z;

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -583,6 +583,15 @@ PrintConfigDef::PrintConfigDef()
     def->ratio_over = "perimeter_extrusion_width";
     def->default_value = new ConfigOptionFloatOrPercent(55, true);
 
+    def = this->add("bridge_infill_overlap", coFloatOrPercent);
+    def->label = "Infill/bridge perimeters overlap";
+    def->category = "Advanced";
+    def->tooltip = "This setting applies an additional overlap between bridging infill and perimeters for better bonding. This can be very useful for unsupported bridges to ensure they are bonded to the perimeters. If expressed as percentage (example: 15%) it is calculated over perimeter extrusion width.";
+    def->sidetext = "mm or %";
+    def->cli = "bridge-infill-overlap=s";
+    def->ratio_over = "perimeter_extrusion_width";
+    def->default_value = new ConfigOptionFloatOrPercent(55, true);
+
     def = this->add("infill_speed", coFloat);
     def->label = "Infill";
     def->category = "Speed";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -217,6 +217,7 @@ class PrintRegionConfig : public virtual StaticPrintConfig
     ConfigOptionFloatOrPercent      infill_extrusion_width;
     ConfigOptionInt                 infill_every_layers;
     ConfigOptionFloatOrPercent      infill_overlap;
+    ConfigOptionFloatOrPercent      bridge_infill_overlap;
     ConfigOptionFloat               infill_speed;
     ConfigOptionBool                overhangs;
     ConfigOptionInt                 perimeter_extruder;
@@ -256,6 +257,7 @@ class PrintRegionConfig : public virtual StaticPrintConfig
         OPT_PTR(infill_extrusion_width);
         OPT_PTR(infill_every_layers);
         OPT_PTR(infill_overlap);
+        OPT_PTR(bridge_infill_overlap);
         OPT_PTR(infill_speed);
         OPT_PTR(overhangs);
         OPT_PTR(perimeter_extruder);

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -273,7 +273,8 @@ PrintObject::invalidate_state_by_config_options(const std::vector<t_config_optio
             || *opt_key == "fill_pattern"
             || *opt_key == "top_infill_extrusion_width"
             || *opt_key == "first_layer_extrusion_width"
-            || *opt_key == "infill_overlap") {
+            || *opt_key == "infill_overlap"
+            || *opt_key == "bridge_infill_overlap") {
             steps.insert(posInfill);
         } else if (*opt_key == "fill_density"
             || *opt_key == "solid_infill_extrusion_width") {


### PR DESCRIPTION
I've been working on a part that is hollow, and thus has a bridging layer as the bottom layer of the top of the part. I noticed that sometimes the infill wouldn't be pressed enough into the perimeter to ensure that it didn't just fall down into the void in the part. I tried adjusting the infill/perimeter overlap, which helped with the bridges but made a mess of the non-bridge infill layers due to the over-extrusion.

This change adds an option to specify the infill/perimeter overlap for bridges. I'm mostly placing this here to get some feedback to see if this is a desirable option, or if there are other techniques in place to address this particular issue.