### PR TITLE
Permit boost libraries to not have the version # in their name

### DIFF
--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -98,11 +98,9 @@ if (defined $ENV{BOOST_LIBRARYDIR}) {
             qw(/opt/local/lib /usr/local/lib /opt/lib /usr/lib /lib);
     }
 }
-
 # In order to generate the -l switches we need to know how Boost libraries are named
 my $have_boost = 0;
 my @boost_libraries = qw(system thread filesystem);  # we need these
-
 # check without explicit lib path (works on Linux)
 if (! $mswin) {
     $have_boost = 1
@@ -122,8 +120,8 @@ if (!$ENV{SLIC3R_STATIC} && $have_boost) {
         # Try to find the boost system library.
         my @files = glob "$path/${lib_prefix}system*$lib_ext";
         next if !@files;
-    
-        if ($files[0] =~ /${lib_prefix}system([^.]+)$lib_ext$/) {
+  
+        if ($files[0] =~ /${lib_prefix}system([^.]*)$lib_ext$/) {
             # Suffix contains the version number, the build type etc.
             my $suffix = $1;
             # Verify existence of all required boost libraries at $path.


### PR DESCRIPTION
From what I can tell, if you're building Boost from source on OSX and set it to be static, the output files will not have a version tag in their extension (the .a files). The boost check in Build.PL requires the version to be in the regex (+). This will match zero or more (*) instead.