### PR TITLE
package Slic3r for OSX post-build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ xs/MANIFEST.bak
 xs/assertlib*
 .init_bundle.ini
 local-lib
+package/osx/Slic3r*.app
+*.dmg

--- a/package/deploy-bintray.sh
+++ b/package/deploy-bintray.sh
@@ -18,9 +18,10 @@ else
 fi
 
 file=$1
+echo "Deploying $file to $version on Bintray..."
 API=${BINTRAY_API_KEY}
 
-curl -v -X POST -d "{ \"name\": \"$version\", \"released\": \"ISO8601 $(date +%Y-%m-%d'T'%H:%M:%S)\",  \"desc\": \"This version...\", \"github_release_notes_file\": \"RELEASE.txt\",  \"github_use_tag_release_notes\": true,  \"vcs_tag\": \"$version\"  }" -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/slic3r_dev/versions
+curl -X POST -d "{ \"name\": \"$version\", \"released\": \"ISO8601 $(date +%Y-%m-%d'T'%H:%M:%S)\",  \"desc\": \"This version...\", \"github_release_notes_file\": \"RELEASE.txt\",  \"github_use_tag_release_notes\": true,  \"vcs_tag\": \"$version\"  }" -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/slic3r_dev/versions
 
 curl -H "X-Bintray-Package: $SLIC3R_PKG" -H "X-Bintray-Version: $version" -H 'X-Bintray-Publish: 1' -H 'X-Bintray-Override: 1'  -T $file -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/$(basename $1)
 

--- a/package/deploy-bintray.sh
+++ b/package/deploy-bintray.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+# Prerequistes
+# Environment variables:
+#   BINTRAY_API_KEY - Working API key
+#   BINTRAY_API_USER - Bintray username.
+#   SLIC3R_VERSION - Development version # for Slic3r
+
+
 if [ $(git describe &>/dev/null) ]; then
-    TAGGED=true
     SLIC3R_BUILD_ID=$(git describe)
-    else
-    TAGGED=false
+else
     SLIC3R_BUILD_ID=${SLIC3R_VERSION}d-$(git rev-parse --short head)
 fi
 
@@ -20,9 +25,12 @@ fi
 file=$1
 echo "Deploying $file to $version on Bintray..."
 API=${BINTRAY_API_KEY}
+USER=${BINTRAY_API_USER}
 
-curl -X POST -d "{ \"name\": \"$version\", \"released\": \"ISO8601 $(date +%Y-%m-%d'T'%H:%M:%S)\",  \"desc\": \"This version...\", \"github_release_notes_file\": \"RELEASE.txt\",  \"github_use_tag_release_notes\": true,  \"vcs_tag\": \"$version\"  }" -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/slic3r_dev/versions
+curl -X POST -d "{ \"name\": \"$version\", \"released\": \"ISO8601 $(date +%Y-%m-%d'T'%H:%M:%S)\",  \"desc\": \"This version...\", \"github_release_notes_file\": \"RELEASE.txt\",  \"github_use_tag_release_notes\": true,  \"vcs_tag\": \"$version\"  }" -u${USER}:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/${SLIC3R_PKG}/versions
 
-curl -H "X-Bintray-Package: $SLIC3R_PKG" -H "X-Bintray-Version: $version" -H 'X-Bintray-Publish: 1' -H 'X-Bintray-Override: 1'  -T $file -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/$(basename $1)
+curl -H "X-Bintray-Package: $SLIC3R_PKG" -H "X-Bintray-Version: $version" -H 'X-Bintray-Publish: 1' -H 'X-Bintray-Override: 1'  -T $file -u${USER}:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/$(basename $1)
+echo "Publishing $file..."
+curl -X POST -u${USER}:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/${SLIC3R_PKG}/$version/publish
 
-curl -H 'Content-Type: application/json' -X PUT -d "{ \"list_in_downloads\":true }" -ulordofhyphens:${API} https://api.bintray.com/file_metadata/lordofhyphens/Slic3r/$(basename $1)
+curl -H 'Content-Type: application/json' -X PUT -d "{ \"list_in_downloads\":true }" -u${USER}:${API} https://api.bintray.com/file_metadata/lordofhyphens/Slic3r/$(basename $1)

--- a/package/deploy-bintray.sh
+++ b/package/deploy-bintray.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+if [ $(git describe &>/dev/null) ]; then
+    TAGGED=true
+    SLIC3R_BUILD_ID=$(git describe)
+    else
+    TAGGED=false
+    SLIC3R_BUILD_ID=${SLIC3R_VERSION}d-$(git rev-parse --short head)
+fi
+
+if [ "$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')" == "master" ]; then
+    # If building master, goes in slic3r_dev
+    SLIC3R_PKG=slic3r_dev
+    version=$SLIC3R_BUILD_ID
+else
+    # If building a branch, put the package somewhere else.
+    SLIC3R_PKG=Slic3r_Branches
+    version=$SLIC3R_BUILD_ID-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')
+fi
+
+file=$1
+API=${BINTRAY_API_KEY}
+
+curl -v -X POST -d "{ \"name\": \"$version\", \"released\": \"ISO8601 $(date +%Y-%m-%d'T'%H:%M:%S)\",  \"desc\": \"This version...\", \"github_release_notes_file\": \"RELEASE.txt\",  \"github_use_tag_release_notes\": true,  \"vcs_tag\": \"$version\"  }" -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/slic3r_dev/versions
+
+curl -H "X-Bintray-Package: $SLIC3R_PKG" -H "X-Bintray-Version: $version" -H 'X-Bintray-Publish: 1' -H 'X-Bintray-Override: 1'  -T $file -ulordofhyphens:${API} https://api.bintray.com/content/lordofhyphens/Slic3r/$(basename $1)
+
+curl -H 'Content-Type: application/json' -X PUT -d "{ \"list_in_downloads\":true }" -ulordofhyphens:${API} https://api.bintray.com/file_metadata/lordofhyphens/Slic3r/$(basename $1)

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
 # Assembles an installation bundle from a built copy of Slic3r.
-# Required environment variables:
+# Requires PAR::Packer to be installed for the version of
+# perl copied.
 # Adapted from script written by bubnikv for Prusa3D.
+# Required environment variables:
 # SLIC3R_VERSION - x.x.x format
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $(basename $0) dmg_name"
+    exit 1;
+fi
 
 WD=$(dirname $0)
 # Determine if this is a tagged (release) commit.

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -24,6 +24,9 @@ else
     appname=Slic3r-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')
     dmgfile=${1}-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!').dmg
 fi
+rm -rf $WD/_tmp
+mkdir -p $WD/_tmp
+
 
 # OSX Application folder shenanigans.
 appfolder="$WD/${appname}.app"
@@ -35,6 +38,7 @@ source $WD/plist.sh
 
 # Our slic3r dir and location of perl
 PERL_BIN=$(which perl)
+PP_BIN=$(which pp)
 SLIC3R_DIR="${WD}/../../"
 
 if [[ -d "${appfolder}" ]]; then
@@ -66,7 +70,15 @@ cp $WD/startup_script.sh $macosfolder/$appname
 chmod +x $macosfolder/$appname
 
 echo "Copying perl from $PERL_BIN"
-cp $PERL_BIN $macosfolder
+cp $PERL_BIN $macosfolder/perl-local
+${PP_BIN} -M POSIX -M FindBin \
+          -M lib -M overload \
+          -M warnings -M local::lib \
+          -M strict -M utf8 -M parent \
+          -B -p -e "print 123" -o $WD/_tmp/test.par
+unzip $WD/_tmp/test.par -d $WD/_tmp/
+cp -r $WD/_tmp/lib/* $macosfolder/local-lib/lib/perl5/
+rm -rf $WD/_tmp
 
 make_plist
 

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -53,7 +53,7 @@ if [[ -d "${appfolder}" ]]; then
     rm -rf ${appfolder}
 fi
 
-if [[ -d "${dmgfile}" ]]; then
+if [[ -e "${dmgfile}" ]]; then
     echo "Deleting old dmg ${dmgfile}."
     rm -rf ${dmgfile}
 fi

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -69,8 +69,8 @@ mv $macosfolder/var/Slic3r.icns $resourcefolder
 
 echo "Copying Slic3r..."
 cp $SLIC3R_DIR/slic3r.pl $macosfolder/slic3r.pl
-cp -r $SLIC3R_DIR/local-lib $macosfolder/local-lib
-cp -r $SLIC3R_DIR/lib/* $macosfolder/local-lib/lib/perl5/
+cp -RP $SLIC3R_DIR/local-lib $macosfolder/local-lib
+cp -RP $SLIC3R_DIR/lib/* $macosfolder/local-lib/lib/perl5/
 
 echo "Copying startup script..."
 cp $WD/startup_script.sh $macosfolder/$appname

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -26,10 +26,10 @@ fi
 # If we're on a branch, add the branch name to the app name.
 if [ "$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')" == "master" ]; then
     appname=Slic3r
-    dmgfile=${1}.dmg
+    dmgfile=slic3r-${SLIC3R_BUILD_ID}-${1}.dmg
 else
     appname=Slic3r-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')
-    dmgfile=${1}-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!').dmg
+    dmgfile=slic3r-${SLIC3R_BUILD_ID}-${1}-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!').dmg
 fi
 rm -rf $WD/_tmp
 mkdir -p $WD/_tmp

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Assembles an installation bundle from a built copy of Slic3r.
+# Required environment variables:
+# Adapted from script written by bubnikv for Prusa3D.
+# SLIC3R_VERSION - x.x.x format
+
+WD=$(dirname $0)
+# Determine if this is a tagged (release) commit.
+# Change the build id accordingly.
+if [ $(git describe &>/dev/null) ]; then
+    TAGGED=true
+    SLIC3R_BUILD_ID=$(git describe)
+else
+    TAGGED=false
+    SLIC3R_BUILD_ID=${SLIC3R_VERSION}d
+fi
+
+# If we're on a branch, add the branch name to the app name.
+if [ "$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')" == "master" ]; then
+    appname=Slic3r
+    dmgfile=${1}.dmg
+else
+    appname=Slic3r-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!')
+    dmgfile=${1}-$(git symbolic-ref HEAD | sed 's!refs\/heads\/!!').dmg
+fi
+
+# OSX Application folder shenanigans.
+appfolder="$WD/${appname}.app"
+macosfolder=$appfolder/Contents/MacOS
+resourcefolder=$appfolder/Contents/Resources
+plistfile=$appfolder/Contents/Info.plist
+PkgInfoContents="APPL????"
+source $WD/plist.sh
+
+# Our slic3r dir and location of perl
+PERL_BIN=$(which perl)
+SLIC3R_DIR="${WD}/../../"
+
+if [[ -d "${appfolder}" ]]; then
+    echo "Deleting old working folder."
+    rm -rf ${appfolder}
+fi
+
+if [[ -d "${dmgfile}" ]]; then
+    echo "Deleting old dmg ${dmgfile}."
+    rm -rf ${dmgfile}
+fi
+
+echo "Creating new app folder at $appfolder."
+mkdir -p $appfolder 
+mkdir -p $macosfolder
+mkdir -p $resourcefolder
+
+echo "Copying resources..." 
+cp -r $SLIC3R_DIR/var $macosfolder/
+mv $macosfolder/var/Slic3r.icns $resourcefolder
+
+echo "Copying Slic3r..."
+cp $SLIC3R_DIR/slic3r.pl $macosfolder/slic3r.pl
+cp -r $SLIC3R_DIR/local-lib $macosfolder/local-lib
+cp -r $SLIC3R_DIR/lib/* $macosfolder/local-lib/lib/perl5/
+
+echo "Copying startup script..."
+cp $WD/startup_script.sh $macosfolder/$appname
+chmod +x $macosfolder/$appname
+
+echo "Copying perl from $PERL_BIN"
+cp $PERL_BIN $macosfolder
+
+make_plist
+
+echo $PkgInfoContents >$appfolder/Contents/PkgInfo
+
+echo "Creating dmg file...."
+hdiutil create -fs HFS+ -srcfolder "$appfolder" -volname "$appname" "$dmgfile"

--- a/package/osx/plist.sh
+++ b/package/osx/plist.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+function make_plist() {
+# Create information property list file (Info.plist).
+echo '<?xml version="1.0" encoding="UTF-8"?>' >$plistfile
+echo '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' >>$plistfile
+echo '<plist version="1.0">' >>$plistfile
+echo '<dict>' >>$plistfile
+echo '  <key>CFBundleExecutable</key>' >>$plistfile
+echo '  <string>'$appname'</string>' >>$plistfile
+echo '  <key>CFBundleGetInfoString</key>' >>$plistfile
+echo "  <string>Slic3r Copyright (C) 2011-$(date +%Y) Alessandro Ranellucci</string>" >>$plistfile
+echo '  <key>CFBundleIconFile</key>' >>$plistfile
+echo '  <string>Slic3r.icns</string>' >>$plistfile
+echo '  <key>CFBundleName</key>' >>$plistfile
+echo '  <string>Slic3r</string>' >>$plistfile
+echo '  <key>CFBundleShortVersionString</key>' >>$plistfile
+if [ $TAGGED ]; then
+    echo "  <string>Slic3r $SLIC3R_BUILD_ID</string>" >>$plistfile
+else 
+    echo "  <string>Slic3r $SLIC3R_BUILD_ID-$(git rev-parse --short head)</string>" >>$plistfile
+fi
+echo '  <key>CFBundleIdentifier</key>' >>$plistfile
+echo '  <string></string>' >>$plistfile
+echo '  <key>CFBundleInfoDictionaryVersion</key>' >>$plistfile
+echo '  <string>6.0</string>' >>$plistfile
+echo '  <key>CFBundlePackageType</key>' >>$plistfile
+echo '  <string>APPL</string>' >>$plistfile
+echo '  <key>CFBundleSignature</key>' >>$plistfile
+echo '  <string>????</string>' >>$plistfile
+echo '  <key>CFBundleVersion</key>' >>$plistfile
+echo "  <string>${SLIC3R_BUILD_ID}</string>" >>$plistfile
+echo '  <key>CFBundleIdentifier</key>' >>$plistfile
+echo '  <string></string>' >>$plistfile
+echo '  <key>CGDisableCoalescedUpdates</key>' >>$plistfile
+echo '  <false/>' >>$plistfile
+echo '</dict>' >>$plistfile
+echo '</plist>' >>$plistfile
+
+}

--- a/package/osx/plist.sh
+++ b/package/osx/plist.sh
@@ -29,6 +29,16 @@ echo '  <key>CFBundleSignature</key>' >>$plistfile
 echo '  <string>????</string>' >>$plistfile
 echo '  <key>CFBundleVersion</key>' >>$plistfile
 echo "  <string>${SLIC3R_BUILD_ID}</string>" >>$plistfile
+echo '  <key>CFBundleTypeRole</key>' >>$plistfile
+echo '  <string>Viewer</string>' >>$plistfile
+# Associate with a few file types (amf, stl, obj)
+echo '  <key>CFBundleTypeExtensions</key>' >>$plistfile
+echo '  <array> ' >> $plistfile
+echo '         <string>stl</string> ' >> $plistfile
+echo '         <string>amf</string> ' >> $plistfile
+echo '         <string>obj</string> ' >> $plistfile
+echo '  </array> ' >> $plistfile
+echo '  <key>LISsAppleDefaultForType</key>   <true/>' >> $plistfile
 echo '  <key>CGDisableCoalescedUpdates</key>' >>$plistfile
 echo '  <false/>' >>$plistfile
 echo '</dict>' >>$plistfile

--- a/package/osx/plist.sh
+++ b/package/osx/plist.sh
@@ -20,7 +20,7 @@ else
     echo "  <string>Slic3r $SLIC3R_BUILD_ID-$(git rev-parse --short head)</string>" >>$plistfile
 fi
 echo '  <key>CFBundleIdentifier</key>' >>$plistfile
-echo '  <string></string>' >>$plistfile
+echo '  <string>org.slic3r.Slic3r</string>' >>$plistfile
 echo '  <key>CFBundleInfoDictionaryVersion</key>' >>$plistfile
 echo '  <string>6.0</string>' >>$plistfile
 echo '  <key>CFBundlePackageType</key>' >>$plistfile
@@ -29,8 +29,6 @@ echo '  <key>CFBundleSignature</key>' >>$plistfile
 echo '  <string>????</string>' >>$plistfile
 echo '  <key>CFBundleVersion</key>' >>$plistfile
 echo "  <string>${SLIC3R_BUILD_ID}</string>" >>$plistfile
-echo '  <key>CFBundleIdentifier</key>' >>$plistfile
-echo '  <string></string>' >>$plistfile
 echo '  <key>CGDisableCoalescedUpdates</key>' >>$plistfile
 echo '  <false/>' >>$plistfile
 echo '</dict>' >>$plistfile

--- a/package/osx/startup_script.sh
+++ b/package/osx/startup_script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR=$(dirname "$0")
+$DIR/perl $DIR/slic3r.pl $@

--- a/package/osx/startup_script.sh
+++ b/package/osx/startup_script.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR=$(dirname "$0")
-$DIR/perl $DIR/slic3r.pl $@
+$DIR/perl-local -I$DIR/local-lib/lib/perl5 $DIR/slic3r.pl $@


### PR DESCRIPTION
Thanks to @bubnikv who provided his sample scripts to build and package. The new local-lib arrangement obviated the need for most of the complexity but the dmg generation was a good model to write my own. 

Should work anywhere that has a working, statically-linked perl. Build server output is OSX 10.9, perl 5.24 (perlbrew).

I don't currently have a test case on a system that isn't the build server.
(next part is getting the build server itself going automagically)