### PR TITLE
Optimistic print time estimator

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -448,14 +448,24 @@ sub new {
                 fil_mm3 => "Used Filament (mm^3)",
                 fil_g   => "Used Filament (g)",
                 cost    => "Cost",
+                time    => "Time (dd:hh:mm:ss)",
+            );
+            my @tooltip = (
+                fil_mm => "Linear mm of filament.",
+                fil_mm3 => "Volume of filament.",
+                fil_g   => "Total weight of filament (in grams). This requires filament density to be set.",
+                cost    => "Total cost in whatever currency you have set.",
+                time    => "Optimistic time estimate for print completion. Only considers travel moves and printing moves.",
             );
             while (my $field = shift @info) {
                 my $label = shift @info;
+                my $tip = shift @tooltip;
                 my $text = Wx::StaticText->new($self, -1, "$label:", wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
                 $text->SetFont($Slic3r::GUI::small_font);
                 $grid_sizer->Add($text, 0);
                 
                 $self->{"print_info_$field"} = Wx::StaticText->new($self, -1, "", wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+                $self->{"print_info_$field"}->SetToolTip($tip);
                 $self->{"print_info_$field"}->SetFont($Slic3r::GUI::small_font);
                 $grid_sizer->Add($self->{"print_info_$field"}, 0);
             }
@@ -1400,6 +1410,8 @@ sub on_export_completed {
     $self->{"print_info_fil_g"}->SetLabel(sprintf("%.2f" , $self->{print}->total_weight));
     $self->{"print_info_fil_mm3"}->SetLabel(sprintf("%.2f" , $self->{print}->total_extruded_volume));
     $self->{"print_info_fil_mm"}->SetLabel(sprintf("%.2f" , $self->{print}->total_used_filament));
+    $self->{"print_info_time"}->SetLabel(sprintf "%02d:%02d:%02d:%02d", (gmtime($self->{print}->total_time))[7,2,1,0]);
+
     
     # this updates buttons status
     $self->object_list_changed;

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -444,6 +444,7 @@ sub new {
             $grid_sizer->AddGrowableCol(3, 1);
             $print_info_sizer->Add($grid_sizer, 0, wxEXPAND);
             my @info = (
+                fil_mm => "Used Filament (mm)",
                 fil_mm3 => "Used Filament (mm^3)",
                 fil_g   => "Used Filament (g)",
                 cost    => "Cost",
@@ -1123,6 +1124,10 @@ sub async_apply_config {
     if ($invalidated) {
         # kill current thread if any
         $self->stop_background_process;
+        # remove the sliced statistics box because something changed.
+        if ($self->{"right_sizer"}) { 
+            $self->{"right_sizer"}->Hide($self->{"sliced_info_box"});
+        }
     } else {
         $self->resume_background_process;
     }
@@ -1394,6 +1399,7 @@ sub on_export_completed {
     $self->{"print_info_cost"}->SetLabel(sprintf("%.2f" , $self->{print}->total_cost));
     $self->{"print_info_fil_g"}->SetLabel(sprintf("%.2f" , $self->{print}->total_weight));
     $self->{"print_info_fil_mm3"}->SetLabel(sprintf("%.2f" , $self->{print}->total_extruded_volume));
+    $self->{"print_info_fil_mm"}->SetLabel(sprintf("%.2f" , $self->{print}->total_used_filament));
     
     # this updates buttons status
     $self->object_list_changed;
@@ -1665,6 +1671,9 @@ sub on_config_change {
             }
             $self->Layout;
         }
+    }
+    if ($self->{"right_sizer"}) { 
+        $self->{"right_sizer"}->Hide($self->{"sliced_info_box"});
     }
     
     return if !$self->GetFrame->is_loaded;

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -142,6 +142,7 @@ sub new {
                         $self->stop_background_process;
                         $self->statusbar->SetStatusText("Slicing cancelled");
                         $self->{preview_notebook}->SetSelection(0);
+
                     });
                     $self->start_background_process;
                 } else {
@@ -457,6 +458,7 @@ sub new {
                 $self->{"print_info_$field"}->SetFont($Slic3r::GUI::small_font);
                 $grid_sizer->Add($self->{"print_info_$field"}, 0);
             }
+            $self->{"sliced_info_box"} = $print_info_sizer;
             
         }
         
@@ -473,6 +475,8 @@ sub new {
         $right_sizer->Add($self->{list}, 1, wxEXPAND, 5);
         $right_sizer->Add($object_info_sizer, 0, wxEXPAND, 0);
         $right_sizer->Add($print_info_sizer, 0, wxEXPAND, 0);
+        $right_sizer->Hide($print_info_sizer);
+        $self->{"right_sizer"} = $right_sizer;
         
         my $hsizer = Wx::BoxSizer->new(wxHORIZONTAL);
         $hsizer->Add($self->{preview_notebook}, 1, wxEXPAND | wxTOP, 1);
@@ -1292,6 +1296,7 @@ sub export_gcode {
     
     # this updates buttons status
     $self->object_list_changed;
+    $self->{"right_sizer"}->Show($self->{"sliced_info_box"});
     
     return $self->{export_gcode_output_file};
 }
@@ -1585,7 +1590,9 @@ sub update {
     } else {
         $self->resume_background_process;
     }
-    
+    if ($self->{"right_sizer"}) { 
+        $self->{"right_sizer"}->Hide($self->{"sliced_info_box"});
+    }
     $self->refresh_canvases;
 }
 

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -431,6 +431,34 @@ sub new {
                 }
             }
         }
+
+        my $print_info_sizer;
+        {
+            my $box = Wx::StaticBox->new($self, -1, "Sliced Info");
+            $print_info_sizer = Wx::StaticBoxSizer->new($box, wxVERTICAL);
+            $print_info_sizer->SetMinSize([350,-1]);
+            my $grid_sizer = Wx::FlexGridSizer->new(2, 2, 5, 5);
+            $grid_sizer->SetFlexibleDirection(wxHORIZONTAL);
+            $grid_sizer->AddGrowableCol(1, 1);
+            $grid_sizer->AddGrowableCol(3, 1);
+            $print_info_sizer->Add($grid_sizer, 0, wxEXPAND);
+            my @info = (
+                fil_mm3 => "Used Filament (mm^3)",
+                fil_g   => "Used Filament (g)",
+                cost    => "Cost",
+            );
+            while (my $field = shift @info) {
+                my $label = shift @info;
+                my $text = Wx::StaticText->new($self, -1, "$label:", wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
+                $text->SetFont($Slic3r::GUI::small_font);
+                $grid_sizer->Add($text, 0);
+                
+                $self->{"print_info_$field"} = Wx::StaticText->new($self, -1, "", wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+                $self->{"print_info_$field"}->SetFont($Slic3r::GUI::small_font);
+                $grid_sizer->Add($self->{"print_info_$field"}, 0);
+            }
+            
+        }
         
         my $buttons_sizer = Wx::BoxSizer->new(wxHORIZONTAL);
         $buttons_sizer->AddStretchSpacer(1);
@@ -444,6 +472,7 @@ sub new {
         $right_sizer->Add($buttons_sizer, 0, wxEXPAND | wxBOTTOM, 5);
         $right_sizer->Add($self->{list}, 1, wxEXPAND, 5);
         $right_sizer->Add($object_info_sizer, 0, wxEXPAND, 0);
+        $right_sizer->Add($print_info_sizer, 0, wxEXPAND, 0);
         
         my $hsizer = Wx::BoxSizer->new(wxHORIZONTAL);
         $hsizer->Add($self->{preview_notebook}, 1, wxEXPAND | wxTOP, 1);
@@ -1346,7 +1375,6 @@ sub on_export_completed {
         } else {
             $message = "G-code file exported to " . $self->{export_gcode_output_file};
         }
-        $message .= sprintf(" Cost: %.2f" , $self->{print}->total_cost);
     } else {
         $message = "Export failed";
     }
@@ -1358,6 +1386,9 @@ sub on_export_completed {
     $self->send_gcode if $send_gcode;
     $self->{print_file} = undef;
     $self->{send_gcode_file} = undef;
+    $self->{"print_info_cost"}->SetLabel(sprintf("%.2f" , $self->{print}->total_cost));
+    $self->{"print_info_fil_g"}->SetLabel(sprintf("%.2f" , $self->{print}->total_weight));
+    $self->{"print_info_fil_mm3"}->SetLabel(sprintf("%.2f" , $self->{print}->total_extruded_volume));
     
     # this updates buttons status
     $self->object_list_changed;

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1346,6 +1346,7 @@ sub on_export_completed {
         } else {
             $message = "G-code file exported to " . $self->{export_gcode_output_file};
         }
+        $message .= sprintf(" Cost: %.2f" , $self->{print}->total_cost);
     } else {
         $message = "Export failed";
     }

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -897,7 +897,7 @@ sub build {
     my $self = shift;
     
     $self->init_config_options(qw(
-        filament_colour filament_diameter filament_notes filament_max_volumetric_speed extrusion_multiplier
+        filament_colour filament_diameter filament_notes filament_max_volumetric_speed extrusion_multiplier filament_density filament_cost
         temperature first_layer_temperature bed_temperature first_layer_bed_temperature
         fan_always_on cooling
         min_fan_speed max_fan_speed bridge_fan_speed disable_fan_first_layers
@@ -912,6 +912,8 @@ sub build {
             $optgroup->append_single_option_line('filament_colour', 0);
             $optgroup->append_single_option_line('filament_diameter', 0);
             $optgroup->append_single_option_line('extrusion_multiplier', 0);
+            $optgroup->append_single_option_line('filament_density', 0);
+            $optgroup->append_single_option_line('filament_cost', 0);
         }
     
         {

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -255,17 +255,33 @@ sub export {
     $self->print->clear_filament_stats;
     $self->print->total_used_filament(0);
     $self->print->total_extruded_volume(0);
+    my $total_filament_weight = 0.0;
+    my $total_filament_cost = 0.0;
     foreach my $extruder (@{$gcodegen->writer->extruders}) {
         my $used_filament = $extruder->used_filament;
         my $extruded_volume = $extruder->extruded_volume;
+        my $filament_weight = $extruded_volume * $extruder->filament_density;
+        my $filament_cost = $filament_weight * ($extruder->filament_cost / 1000);
         $self->print->set_filament_stats($extruder->id, $used_filament);
         
         printf $fh "; filament used = %.1fmm (%.1fcm3)\n",
             $used_filament, $extruded_volume/1000;
+        if ($filament_weight > 0) {
+            $total_filament_weight += $filament_weight;
+            printf $fh "; filament used = %.1fg\n",
+                   $filament_weight;
+            if ($filament_cost > 0) {
+                $total_filament_cost += $filament_cost;
+                printf $fh "; filament cost = %.1f\n",
+                       $filament_cost;
+            }
+        }
         
         $self->print->total_used_filament($self->print->total_used_filament + $used_filament);
         $self->print->total_extruded_volume($self->print->total_extruded_volume + $extruded_volume);
     }
+    printf $fh "; total filament cost = %.1f\n",
+           $total_filament_cost;
     
     # append full config
     print $fh "\n";

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -260,7 +260,7 @@ sub export {
     foreach my $extruder (@{$gcodegen->writer->extruders}) {
         my $used_filament = $extruder->used_filament;
         my $extruded_volume = $extruder->extruded_volume;
-        my $filament_weight = $extruded_volume * $extruder->filament_density;
+        my $filament_weight = $extruded_volume * $extruder->filament_density / 1000;
         my $filament_cost = $filament_weight * ($extruder->filament_cost / 1000);
         $self->print->set_filament_stats($extruder->id, $used_filament);
         

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -257,11 +257,13 @@ sub export {
     $self->print->total_extruded_volume(0);
     $self->print->total_weight(0);
     $self->print->total_cost(0);
+    $self->print->total_time(0);
     foreach my $extruder (@{$gcodegen->writer->extruders}) {
         my $used_filament = $extruder->used_filament;
         my $extruded_volume = $extruder->extruded_volume;
         my $filament_weight = $extruded_volume * $extruder->filament_density / 1000;
         my $filament_cost = $filament_weight * ($extruder->filament_cost / 1000);
+        my $extrusion_time = $extruder->extrusion_time;
         $self->print->set_filament_stats($extruder->id, $used_filament);
         
         printf $fh "; filament used = %.1fmm (%.1fcm3)\n",
@@ -276,8 +278,11 @@ sub export {
                        $filament_cost;
             }
         }
+        printf $fh "; estimated print time (optimistic) = %02d:%02d:%02d:%02d (days:h:m:s)\n", 
+            (gmtime($extrusion_time))[7,2,1,0];
         
         $self->print->total_used_filament($self->print->total_used_filament + $used_filament);
+        $self->print->total_time($self->print->total_time + $extrusion_time);
         $self->print->total_extruded_volume($self->print->total_extruded_volume + $extruded_volume);
     }
     printf $fh "; total filament cost = %.1f\n",

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -255,8 +255,8 @@ sub export {
     $self->print->clear_filament_stats;
     $self->print->total_used_filament(0);
     $self->print->total_extruded_volume(0);
-    my $total_filament_weight = 0.0;
-    my $total_filament_cost = 0.0;
+    $self->print->total_weight(0);
+    $self->print->total_cost(0);
     foreach my $extruder (@{$gcodegen->writer->extruders}) {
         my $used_filament = $extruder->used_filament;
         my $extruded_volume = $extruder->extruded_volume;
@@ -267,11 +267,11 @@ sub export {
         printf $fh "; filament used = %.1fmm (%.1fcm3)\n",
             $used_filament, $extruded_volume/1000;
         if ($filament_weight > 0) {
-            $total_filament_weight += $filament_weight;
+            $self->print->total_weight($self->print->total_weight + $filament_weight);
             printf $fh "; filament used = %.1fg\n",
                    $filament_weight;
             if ($filament_cost > 0) {
-                $total_filament_cost += $filament_cost;
+                $self->print->total_cost($self->print->total_cost + $filament_cost);
                 printf $fh "; filament cost = %.1f\n",
                        $filament_cost;
             }
@@ -281,7 +281,7 @@ sub export {
         $self->print->total_extruded_volume($self->print->total_extruded_volume + $extruded_volume);
     }
     printf $fh "; total filament cost = %.1f\n",
-           $total_filament_cost;
+           $self->print->total_cost;
     
     # append full config
     print $fh "\n";

--- a/lib/Slic3r/Print/Object.pm
+++ b/lib/Slic3r/Print/Object.pm
@@ -417,6 +417,8 @@ sub generate_support_material {
     $self->_support_material->generate($self);
     
     $self->set_step_done(STEP_SUPPORTMATERIAL);
+    my $stats = "Weight: %.1fg, Cost: %.1f" , $self->print->total_weight, $self->print->total_cost;
+    $self->print->status_cb->(85, $stats);
 }
 
 sub _support_material {

--- a/xs/src/libslic3r/Extruder.cpp
+++ b/xs/src/libslic3r/Extruder.cpp
@@ -112,6 +112,18 @@ Extruder::filament_diameter() const
 }
 
 double
+Extruder::filament_density() const
+{
+    return this->config->filament_density.get_at(this->id);
+}
+
+double
+Extruder::filament_cost() const
+{
+    return this->config->filament_cost.get_at(this->id);
+}
+
+double
 Extruder::extrusion_multiplier() const
 {
     return this->config->extrusion_multiplier.get_at(this->id);

--- a/xs/src/libslic3r/Extruder.cpp
+++ b/xs/src/libslic3r/Extruder.cpp
@@ -4,7 +4,8 @@ namespace Slic3r {
 
 Extruder::Extruder(unsigned int id, GCodeConfig *config)
 :   id(id),
-    config(config)
+    config(config),
+    time_used(0.0)
 {
     reset();
     
@@ -163,6 +164,43 @@ double
 Extruder::retract_restart_extra_toolchange() const
 {
     return this->config->retract_restart_extra_toolchange.get_at(this->id);
+}
+
+// Wildly optimistic acceleration "bell" curve modeling.
+// Adds an estimate of how long the move with a given accel
+// takes, in seconds, to the extruder's total time count.
+// It is assumed that the movement is smooth and uniform.
+void
+Extruder::add_extrusion_time(double length, double v, double acceleration) 
+{
+    // for half of the move, there are 2 zones, where the speed is increasing/decreasing and 
+    // where the speed is constant.
+    // Since the slowdown is assumed to be uniform, calculate the average velocity for half of the 
+    // expected displacement.
+    // final velocity v = a*t => a * (dx / 0.5v) => v^2 = 2*a*dx
+    // v_avg = 0.5v => 2*v_avg = v
+    // d_x = v_avg*t => t = d_x / v_avg
+    acceleration = (acceleration == 0.0 ? 4000.0 : acceleration); // Set a default accel to use for print time in case it's 0 somehow.
+    auto half_length = length / 2.0;
+    auto t_init = v / acceleration; // time to final velocity
+    auto dx_init = (0.5*v*t_init); // Initial displacement for the time to get to final velocity
+    auto t = 0.0;
+    if (half_length >= dx_init) {
+        half_length -= (0.5*v*t_init);
+        t += t_init;
+        t += (half_length / v); // rest of time is at constant speed.
+    } else {
+        // If too much displacement for the expected final velocity, we don't hit the max, so reduce 
+        // the average velocity to fit the displacement we actually are looking for.
+        t += std::sqrt(std::abs(length) * 2.0 * acceleration) / acceleration;
+    }
+    this->time_used += 2.0*t; // cut in half before, so double to get full time spent.
+}
+
+double
+Extruder::extrusion_time() const
+{
+    return this->time_used;
 }
 
 }

--- a/xs/src/libslic3r/Extruder.hpp
+++ b/xs/src/libslic3r/Extruder.hpp
@@ -29,6 +29,8 @@ class Extruder
     double used_filament() const;
     
     double filament_diameter() const;
+    double filament_density() const;
+    double filament_cost() const;
     double extrusion_multiplier() const;
     double retract_length() const;
     double retract_lift() const;

--- a/xs/src/libslic3r/Extruder.hpp
+++ b/xs/src/libslic3r/Extruder.hpp
@@ -17,6 +17,7 @@ class Extruder
     double restart_extra;
     double e_per_mm3;
     double retract_speed_mm_min;
+    double time_used;
     
     Extruder(unsigned int id, GCodeConfig *config);
     virtual ~Extruder() {}
@@ -38,6 +39,8 @@ class Extruder
     double retract_restart_extra() const;
     double retract_length_toolchange() const;
     double retract_restart_extra_toolchange() const;
+    void add_extrusion_time(double length, double v, double acceleration);
+    double extrusion_time() const;
     
     private:
     GCodeConfig *config;

--- a/xs/src/libslic3r/Print.cpp
+++ b/xs/src/libslic3r/Print.cpp
@@ -54,7 +54,8 @@ template class PrintState<PrintObjectStep>;
 
 Print::Print()
 :   total_used_filament(0),
-    total_extruded_volume(0)
+    total_extruded_volume(0),
+    total_time(0)
 {
 }
 

--- a/xs/src/libslic3r/Print.hpp
+++ b/xs/src/libslic3r/Print.hpp
@@ -167,7 +167,7 @@ class Print
     PrintRegionPtrs regions;
     PlaceholderParser placeholder_parser;
     // TODO: status_cb
-    double total_used_filament, total_extruded_volume;
+    double total_used_filament, total_extruded_volume, total_cost, total_weight;
     std::map<size_t,float> filament_stats;
     PrintState<PrintStep> state;
 

--- a/xs/src/libslic3r/Print.hpp
+++ b/xs/src/libslic3r/Print.hpp
@@ -167,7 +167,7 @@ class Print
     PrintRegionPtrs regions;
     PlaceholderParser placeholder_parser;
     // TODO: status_cb
-    double total_used_filament, total_extruded_volume, total_cost, total_weight;
+    double total_used_filament, total_extruded_volume, total_cost, total_weight, total_time;
     std::map<size_t,float> filament_stats;
     PrintState<PrintStep> state;
 

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -355,6 +355,30 @@ PrintConfigDef::PrintConfigDef()
         opt->values.push_back(3);
         def->default_value = opt;
     }
+
+    def = this->add("filament_density", coFloats);
+    def->label = "Density";
+    def->tooltip = "Enter your filament density here. This is only for statistical information. A decent way is to weigh a known length of filament and compute the ratio of the length to volume.";
+    def->sidetext = "g/mm^3";
+    def->cli = "filament-density=f@";
+    def->min = 0;
+    {
+        ConfigOptionFloats* opt = new ConfigOptionFloats();
+        opt->values.push_back(0);
+        def->default_value = opt;
+    }
+
+    def = this->add("filament_cost", coFloats);
+    def->label = "Cost";
+    def->tooltip = "Enter your filament cost per kg here. This is only for statistical information.";
+    def->sidetext = "money/kg";
+    def->cli = "filament-cost=f@";
+    def->min = 0;
+    {
+        ConfigOptionFloats* opt = new ConfigOptionFloats();
+        opt->values.push_back(0);
+        def->default_value = opt;
+    }
     
     def = this->add("filament_settings_id", coString);
     def->default_value = new ConfigOptionString("");

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -358,8 +358,8 @@ PrintConfigDef::PrintConfigDef()
 
     def = this->add("filament_density", coFloats);
     def->label = "Density";
-    def->tooltip = "Enter your filament density here. This is only for statistical information. A decent way is to weigh a known length of filament and compute the ratio of the length to volume.";
-    def->sidetext = "g/mm^3";
+    def->tooltip = "Enter your filament density here. This is only for statistical information. A decent way is to weigh a known length of filament and compute the ratio of the length to volume. Better is to calculate the volume directly through displacement.";
+    def->sidetext = "g/cm^3";
     def->cli = "filament-density=f@";
     def->min = 0;
     {

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -289,6 +289,8 @@ class GCodeConfig : public virtual StaticPrintConfig
     ConfigOptionString              extrusion_axis;
     ConfigOptionFloats              extrusion_multiplier;
     ConfigOptionFloats              filament_diameter;
+    ConfigOptionFloats              filament_density;
+    ConfigOptionFloats              filament_cost;
     ConfigOptionFloats              filament_max_volumetric_speed;
     ConfigOptionBool                gcode_comments;
     ConfigOptionEnum<GCodeFlavor>   gcode_flavor;
@@ -322,6 +324,8 @@ class GCodeConfig : public virtual StaticPrintConfig
         OPT_PTR(extrusion_axis);
         OPT_PTR(extrusion_multiplier);
         OPT_PTR(filament_diameter);
+        OPT_PTR(filament_density);
+        OPT_PTR(filament_cost);
         OPT_PTR(filament_max_volumetric_speed);
         OPT_PTR(gcode_comments);
         OPT_PTR(gcode_flavor);

--- a/xs/xsp/Extruder.xsp
+++ b/xs/xsp/Extruder.xsp
@@ -42,6 +42,8 @@
         %code%{ RETVAL = THIS->retract_speed_mm_min; %};
     
     double filament_diameter();
+    double filament_density();
+    double filament_cost();
     double extrusion_multiplier();
     double retract_length();
     double retract_lift();

--- a/xs/xsp/Extruder.xsp
+++ b/xs/xsp/Extruder.xsp
@@ -51,4 +51,5 @@
     double retract_restart_extra();
     double retract_length_toolchange();
     double retract_restart_extra_toolchange();
+    double extrusion_time();
 };

--- a/xs/xsp/Print.xsp
+++ b/xs/xsp/Print.xsp
@@ -309,5 +309,14 @@ Print::total_cost(...)
     OUTPUT:
         RETVAL
 
+double
+Print::total_time(...)
+    CODE:
+        if (items > 1) {
+            THIS->total_time = (double)SvNV(ST(1));
+        }
+        RETVAL = THIS->total_time;
+    OUTPUT:
+        RETVAL
 %}
 };

--- a/xs/xsp/Print.xsp
+++ b/xs/xsp/Print.xsp
@@ -288,5 +288,26 @@ Print::total_extruded_volume(...)
     OUTPUT:
         RETVAL
 
+
+double
+Print::total_weight(...)
+    CODE:
+        if (items > 1) {
+            THIS->total_weight = (double)SvNV(ST(1));
+        }
+        RETVAL = THIS->total_weight;
+    OUTPUT:
+        RETVAL
+
+double
+Print::total_cost(...)
+    CODE:
+        if (items > 1) {
+            THIS->total_cost = (double)SvNV(ST(1));
+        }
+        RETVAL = THIS->total_cost;
+    OUTPUT:
+        RETVAL
+
 %}
 };


### PR DESCRIPTION
Add an optimistic print time estimator to Slic3r. Considers just the print and travel moves under ideal circumstances. The information is collected during gcode generation per-extruder and then summed at the end. 

This PR requires that #3669 be merged first (adds slicing statistic box)

Implements #1766 (along with #3669).