### PR TITLE
Fix #2861, provide consistent mouse-wheel zoom direction, plus a GUI preference to invert

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -67,6 +67,7 @@ our $Settings = {
         mode => 'simple',
         version_check => 1,
         autocenter => 1,
+        invert_zoom => 0,
         background_processing => 0,
         # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
         # By default, Prusa has the controller hidden.
@@ -124,6 +125,7 @@ sub OnInit {
         $last_version = $Settings->{_}{version};
         $Settings->{_}{mode} ||= 'expert';
         $Settings->{_}{autocenter} //= 1;
+        $Settings->{_}{invert_zoom} //= 0;
         $Settings->{_}{background_processing} //= 1;
         # If set, the "Controller" tab for the control of the printer over serial line and the serial port settings are hidden.
         $Settings->{_}{no_controller} //= 1;

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -127,6 +127,9 @@ sub new {
         
         # Calculate the zoom delta and apply it to the current zoom factor
         my $zoom = $e->GetWheelRotation() / $e->GetWheelDelta();
+        if ($Slic3r::GUI::Settings->{_}{invert_zoom}) {
+            $zoom *= -1;
+        }
         $zoom = max(min($zoom, 4), -4);
         $zoom /= 10;
         $self->_zoom($self->_zoom / (1-$zoom));

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -180,6 +180,9 @@ sub new {
         
         # Calculate the zoom delta and apply it to the current zoom factor
         my $zoom = -$e->GetWheelRotation() / $e->GetWheelDelta();
+        if ($Slic3r::GUI::Settings->{_}{invert_zoom}) {
+            $zoom *= -1;
+        }
         $zoom = max(min($zoom, 4), -4);
         $zoom /= 10;
         $self->_zoom($self->_zoom / (1-$zoom));

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -179,7 +179,7 @@ sub new {
         my $old_zoom = $self->_zoom;
         
         # Calculate the zoom delta and apply it to the current zoom factor
-        my $zoom = $e->GetWheelRotation() / $e->GetWheelDelta();
+        my $zoom = -$e->GetWheelRotation() / $e->GetWheelDelta();
         $zoom = max(min($zoom, 4), -4);
         $zoom /= 10;
         $self->_zoom($self->_zoom / (1-$zoom));

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -53,6 +53,13 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{autocenter},
     ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+        opt_id      => 'invert_zoom',
+        type        => 'bool',
+        label       => 'Invert zoom in previews',
+        tooltip     => 'If this is enabled, Slic3r will invert the direction of mouse-wheel zoom in preview panes.',
+        default     => $Slic3r::GUI::Settings->{_}{invert_zoom},
+    ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'background_processing',
         type        => 'bool',
         label       => 'Background processing',


### PR DESCRIPTION
The first commit makes mouse-wheel zooming act the same across the 2D and 3D views. Up zooms in, down zooms out (same as OpenSCAD, Inkscape, KISSlicer, web browsers etc).

Then, for those who prefer zooming to go in the opposite direction, there is now a GUI preference to invert the direction (zoom direction like Meshlab, don't know what else).
