### PR TITLE
Configurable overhang threshold as function of perimeter width

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -482,7 +482,7 @@ sub build {
         brim_connections_width brim_width
         support_material support_material_threshold support_material_enforce_layers
         raft_layers
-        support_material_pattern support_material_spacing support_material_angle
+        support_material_pattern support_material_spacing support_material_angle support_material_auto_overhang_threshold
         support_material_interface_layers support_material_interface_spacing
         support_material_contact_distance dont_support_bridges
         notes
@@ -582,6 +582,7 @@ sub build {
             my $optgroup = $page->new_optgroup('Support material');
             $optgroup->append_single_option_line('support_material');
             $optgroup->append_single_option_line('support_material_threshold');
+            $optgroup->append_single_option_line('support_material_auto_overhang_threshold');
             $optgroup->append_single_option_line('support_material_enforce_layers');
         }
         {
@@ -863,11 +864,16 @@ sub _update {
     
     my $have_support_material = $config->support_material || $config->raft_layers > 0;
     my $have_support_interface = $config->support_material_interface_layers > 0;
+    my $have_automatic_support =  $have_support_material && $config->support_material_threshold == 0;
     $self->get_field($_)->toggle($have_support_material)
-        for qw(support_material_threshold support_material_pattern
+        for qw(support_material_threshold support_material_pattern 
             support_material_spacing support_material_angle
             support_material_interface_layers dont_support_bridges
             support_material_extrusion_width support_material_contact_distance);
+
+    $self->get_field($_)->toggle($have_automatic_support)
+        for qw(support_material_auto_overhang_threshold);
+
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)
         for qw(support_material_interface_spacing support_material_interface_extruder
             support_material_interface_speed);

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -482,7 +482,7 @@ sub build {
         brim_connections_width brim_width
         support_material support_material_threshold support_material_enforce_layers
         raft_layers
-        support_material_pattern support_material_spacing support_material_angle support_material_auto_overhang_threshold
+        support_material_pattern support_material_spacing support_material_angle 
         support_material_interface_layers support_material_interface_spacing
         support_material_contact_distance dont_support_bridges
         notes
@@ -582,7 +582,6 @@ sub build {
             my $optgroup = $page->new_optgroup('Support material');
             $optgroup->append_single_option_line('support_material');
             $optgroup->append_single_option_line('support_material_threshold');
-            $optgroup->append_single_option_line('support_material_auto_overhang_threshold');
             $optgroup->append_single_option_line('support_material_enforce_layers');
         }
         {
@@ -864,15 +863,11 @@ sub _update {
     
     my $have_support_material = $config->support_material || $config->raft_layers > 0;
     my $have_support_interface = $config->support_material_interface_layers > 0;
-    my $have_automatic_support =  $have_support_material && $config->support_material_threshold == 0;
     $self->get_field($_)->toggle($have_support_material)
         for qw(support_material_threshold support_material_pattern 
             support_material_spacing support_material_angle
             support_material_interface_layers dont_support_bridges
             support_material_extrusion_width support_material_contact_distance);
-
-    $self->get_field($_)->toggle($have_automatic_support)
-        for qw(support_material_auto_overhang_threshold);
 
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)
         for qw(support_material_interface_spacing support_material_interface_extruder

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -152,7 +152,7 @@ sub contact_area {
                 } else {
                     $diff = diff(
                         [ map $_->p, @{$layerm->slices} ],
-                        offset([ map @$_, @{$lower_layer->slices} ], +$fw*2),
+                        offset([ map @$_, @{$lower_layer->slices} ], +$fw/2),
                     );
                 
                     # collapse very tiny spots

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -92,7 +92,7 @@ sub contact_area {
     
     # if user specified a custom angle threshold, convert it to radians
     my $threshold_rad;
-    if ($self->object_config->support_material_threshold) {
+    if (!$self->object_config->support_material_threshold =~ /%$/) {
         $threshold_rad = deg2rad($self->object_config->support_material_threshold + 1);  # +1 makes the threshold inclusive
         Slic3r::debugf "Threshold angle = %d°\n", rad2deg($threshold_rad);
     }
@@ -152,7 +152,7 @@ sub contact_area {
                 } else {
                     $diff = diff(
                         [ map $_->p, @{$layerm->slices} ],
-                        offset([ map @$_, @{$lower_layer->slices} ], +$fw*($self->object_config->support_material_auto_overhang_threshold/100.0)),
+                        offset([ map @$_, @{$lower_layer->slices} ], +$self->object_config->get_abs_value_over('support_material_threshold', $fw)),
                     );
                 
                     # collapse very tiny spots

--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -152,7 +152,7 @@ sub contact_area {
                 } else {
                     $diff = diff(
                         [ map $_->p, @{$layerm->slices} ],
-                        offset([ map @$_, @{$lower_layer->slices} ], +$fw/2),
+                        offset([ map @$_, @{$lower_layer->slices} ], +$fw*($self->object_config->support_material_auto_overhang_threshold/100.0)),
                     );
                 
                     # collapse very tiny spots

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1183,34 +1183,6 @@ PrintConfigDef::PrintConfigDef()
     def->max = 359;
     def->default_value = new ConfigOptionInt(0);
 
-    def = this->add("support_material_auto_overhang_threshold", coPercent);
-    def->label = "Perimeter Width % Considered unsupported";
-    def->category = "Support material";
-    def->tooltip = "The percentage of the perimeter width to consider as unsupported with regards to automatic overhang detection.";
-    def->sidetext = "%";
-    def->cli = "support-material-auto_overhang_threshold=f";
-    def->min = 0;
-    def->max = 200;
-    def->enum_values.push_back("30");
-    def->enum_values.push_back("40");
-    def->enum_values.push_back("50");
-    def->enum_values.push_back("60");
-    def->enum_values.push_back("70");
-    def->enum_values.push_back("80");
-    def->enum_values.push_back("90");
-    def->enum_values.push_back("100");
-    def->enum_values.push_back("200");
-    def->enum_labels.push_back("30%");
-    def->enum_labels.push_back("40%");
-    def->enum_labels.push_back("50%");
-    def->enum_labels.push_back("60%");
-    def->enum_labels.push_back("70%");
-    def->enum_labels.push_back("80%");
-    def->enum_labels.push_back("90%");
-    def->enum_labels.push_back("100%");
-    def->enum_labels.push_back("200%");
-    def->default_value = new ConfigOptionPercent(60);
-
     def = this->add("support_material_contact_distance", coFloat);
     def->gui_type = "f_enum_open";
     def->label = "Contact Z distance";
@@ -1334,15 +1306,15 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("auto");
     def->default_value = new ConfigOptionFloat(60);
 
-    def = this->add("support_material_threshold", coInt);
+    def = this->add("support_material_threshold", coFloatOrPercent);
     def->label = "Overhang threshold";
     def->category = "Support material";
-    def->tooltip = "Support material will not be generated for overhangs whose slope angle (90° = vertical) is above the given threshold. In other words, this value represent the most horizontal slope (measured from the horizontal plane) that you can print without support material. Set to zero for automatic detection (recommended).";
-    def->sidetext = "°";
-    def->cli = "support-material-threshold=i";
+    def->tooltip = "Support material will not be generated for overhangs whose slope angle (90° = vertical) is above the given threshold. In other words, this value represent the most horizontal slope (measured from the horizontal plane) that you can print without support material. Set to a percentage to automatically detect based on some % of overhanging perimeter width instead (recommended).";
+    def->sidetext = "° (or %)";
+    def->cli = "support-material-threshold=s";
     def->min = 0;
-    def->max = 90;
-    def->default_value = new ConfigOptionInt(0);
+    def->max = 300;
+    def->default_value = new ConfigOptionFloatOrPercent(60, true);
 
     def = this->add("temperature", coInts);
     def->label = "Other layers";

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1191,12 +1191,6 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "support-material-auto_overhang_threshold=f";
     def->min = 0;
     def->max = 200;
-    def->enum_values.push_back("0");
-    def->enum_values.push_back("5");
-    def->enum_values.push_back("10");
-    def->enum_values.push_back("15");
-    def->enum_values.push_back("20");
-    def->enum_values.push_back("25");
     def->enum_values.push_back("30");
     def->enum_values.push_back("40");
     def->enum_values.push_back("50");
@@ -1206,12 +1200,6 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("90");
     def->enum_values.push_back("100");
     def->enum_values.push_back("200");
-    def->enum_labels.push_back("0%");
-    def->enum_labels.push_back("5%");
-    def->enum_labels.push_back("10%");
-    def->enum_labels.push_back("15%");
-    def->enum_labels.push_back("20%");
-    def->enum_labels.push_back("25%");
     def->enum_labels.push_back("30%");
     def->enum_labels.push_back("40%");
     def->enum_labels.push_back("50%");
@@ -1221,7 +1209,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("90%");
     def->enum_labels.push_back("100%");
     def->enum_labels.push_back("200%");
-    def->default_value = new ConfigOptionPercent(200);
+    def->default_value = new ConfigOptionPercent(60);
 
     def = this->add("support_material_contact_distance", coFloat);
     def->gui_type = "f_enum_open";

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1183,6 +1183,46 @@ PrintConfigDef::PrintConfigDef()
     def->max = 359;
     def->default_value = new ConfigOptionInt(0);
 
+    def = this->add("support_material_auto_overhang_threshold", coPercent);
+    def->label = "Perimeter Width % Considered unsupported";
+    def->category = "Support material";
+    def->tooltip = "The percentage of the perimeter width to consider as unsupported with regards to automatic overhang detection.";
+    def->sidetext = "%";
+    def->cli = "support-material-auto_overhang_threshold=f";
+    def->min = 0;
+    def->max = 200;
+    def->enum_values.push_back("0");
+    def->enum_values.push_back("5");
+    def->enum_values.push_back("10");
+    def->enum_values.push_back("15");
+    def->enum_values.push_back("20");
+    def->enum_values.push_back("25");
+    def->enum_values.push_back("30");
+    def->enum_values.push_back("40");
+    def->enum_values.push_back("50");
+    def->enum_values.push_back("60");
+    def->enum_values.push_back("70");
+    def->enum_values.push_back("80");
+    def->enum_values.push_back("90");
+    def->enum_values.push_back("100");
+    def->enum_values.push_back("200");
+    def->enum_labels.push_back("0%");
+    def->enum_labels.push_back("5%");
+    def->enum_labels.push_back("10%");
+    def->enum_labels.push_back("15%");
+    def->enum_labels.push_back("20%");
+    def->enum_labels.push_back("25%");
+    def->enum_labels.push_back("30%");
+    def->enum_labels.push_back("40%");
+    def->enum_labels.push_back("50%");
+    def->enum_labels.push_back("60%");
+    def->enum_labels.push_back("70%");
+    def->enum_labels.push_back("80%");
+    def->enum_labels.push_back("90%");
+    def->enum_labels.push_back("100%");
+    def->enum_labels.push_back("200%");
+    def->default_value = new ConfigOptionPercent(200);
+
     def = this->add("support_material_contact_distance", coFloat);
     def->gui_type = "f_enum_open";
     def->label = "Contact Z distance";
@@ -1290,6 +1330,9 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "support-material-spacing=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(2.5);
+
+
+
 
     def = this->add("support_material_speed", coFloat);
     def->label = "Support material";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -150,6 +150,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     ConfigOptionEnum<SeamPosition>  seam_position;
     ConfigOptionBool                support_material;
     ConfigOptionInt                 support_material_angle;
+    ConfigOptionPercent             support_material_auto_overhang_threshold;
     ConfigOptionFloat               support_material_contact_distance;
     ConfigOptionInt                 support_material_enforce_layers;
     ConfigOptionInt                 support_material_extruder;
@@ -180,6 +181,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
         OPT_PTR(seam_position);
         OPT_PTR(support_material);
         OPT_PTR(support_material_angle);
+        OPT_PTR(support_material_auto_overhang_threshold);
         OPT_PTR(support_material_contact_distance);
         OPT_PTR(support_material_enforce_layers);
         OPT_PTR(support_material_extruder);

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -150,7 +150,6 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     ConfigOptionEnum<SeamPosition>  seam_position;
     ConfigOptionBool                support_material;
     ConfigOptionInt                 support_material_angle;
-    ConfigOptionPercent             support_material_auto_overhang_threshold;
     ConfigOptionFloat               support_material_contact_distance;
     ConfigOptionInt                 support_material_enforce_layers;
     ConfigOptionInt                 support_material_extruder;
@@ -162,7 +161,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     ConfigOptionEnum<SupportMaterialPattern> support_material_pattern;
     ConfigOptionFloat               support_material_spacing;
     ConfigOptionFloat               support_material_speed;
-    ConfigOptionInt                 support_material_threshold;
+    ConfigOptionFloatOrPercent      support_material_threshold;
     ConfigOptionFloat               xy_size_compensation;
     
     PrintObjectConfig(bool initialize = true) : StaticPrintConfig() {
@@ -181,7 +180,6 @@ class PrintObjectConfig : public virtual StaticPrintConfig
         OPT_PTR(seam_position);
         OPT_PTR(support_material);
         OPT_PTR(support_material_angle);
-        OPT_PTR(support_material_auto_overhang_threshold);
         OPT_PTR(support_material_contact_distance);
         OPT_PTR(support_material_enforce_layers);
         OPT_PTR(support_material_extruder);


### PR DESCRIPTION
Sets the default as well to 60% (as stipulated by https://github.com/alexrj/Slic3r/wiki/Support:-Requirements)

Extends #2098 
Fixes #2068

Using test case from #2068 and setting value to new default:
![image](https://cloud.githubusercontent.com/assets/31754/23825300/aecace2c-064c-11e7-8c00-c18b6e5de21f.png)

The option is only considered for auto threshold angle. 