### PR TITLE
Use default size for label and size column label to fit content.

### DIFF
--- a/lib/Slic3r/GUI/Plater/ObjectSettingsDialog.pm
+++ b/lib/Slic3r/GUI/Plater/ObjectSettingsDialog.pm
@@ -77,7 +77,7 @@ sub new {
     
     {
         my $label = Wx::StaticText->new($self, -1, "You can use this section to override the default layer height for parts of this object. Set layer height to zero to skip portions of the input file.",
-            wxDefaultPosition, [-1, 40]);
+            wxDefaultPosition, wxDefaultSize);
         $label->SetFont(Wx::SystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
         $sizer->Add($label, 0, wxEXPAND | wxALL, 10);
     }
@@ -90,7 +90,7 @@ sub new {
     $grid->SetColLabelValue(0, "Min Z (mm)");
     $grid->SetColLabelValue(1, "Max Z (mm)");
     $grid->SetColLabelValue(2, "Layer height (mm)");
-    $grid->SetColSize($_, 135) for 0..2;
+    $grid->SetColSize($_, -1) for 0..2;
     $grid->SetDefaultCellAlignment(wxALIGN_CENTRE, wxALIGN_CENTRE);
     
     # load data


### PR DESCRIPTION
Because of issue #1300 , I also see labels that are cut off:
![slic3r_object_settings_cutoff](https://cloud.githubusercontent.com/assets/489253/24027039/0c023344-0a82-11e7-81e7-3f0a6d0abf74.png)
 
This pull request fixes the cut off text on the object settings dialog:
![slic3r_object_settings_resized](https://cloud.githubusercontent.com/assets/489253/24027063/2502ef28-0a82-11e7-8674-901400923797.png)
