### PR TITLE
Remove unused --no-plater option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Contributions by Henrik Brix Andersen, Nicolas Dandrimont, Mark Hindess, Petr Le
       GUI options:
         --gui               Forces the GUI launch instead of command line slicing (if you
                             supply a model file, it will be loaded into the plater)
-        --no-plater         Disable the plater tab
         --autosave <file>   Automatically export current configuration to the specified file
     
       Output options:

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -326,7 +326,6 @@ $j
   GUI options:
     --gui               Forces the GUI launch instead of command line slicing (if you
                         supply a model file, it will be loaded into the plater)
-    --no-plater         Disable the plater tab
     --autosave <file>   Automatically export current configuration to the specified file
 
   Output options:


### PR DESCRIPTION
Option `--no-plater` is unknown since merge `gui3` branch, so it mus be removed from `slic3r.pl` and `README.md`.