### PR TITLE
Use wxpar instead of manually copying libs.

### DIFF
--- a/package/linux/make_archive.sh
+++ b/package/linux/make_archive.sh
@@ -86,6 +86,8 @@ cp -rf $WD/_tmp/lib/* $archivefolder/local-lib/lib/perl5/
 cp -rf $WD/_tmp/shlib $archivefolder/
 
 rm -rf $WD/_tmp
+echo "Adding .desktop file"
+sed -e "s|SLIC3R_VERSION|$SLIC3R_VERSION|" -e "s|APPLICATION_NAME|Slic3r|" $WD/slic3r.desktop.in > $archivefolder/Slic3r.desktop
 
 echo "Cleaning local-lib"
 rm -rf $archivefolder/local-lib/bin

--- a/package/linux/make_archive.sh
+++ b/package/linux/make_archive.sh
@@ -67,22 +67,6 @@ cp $SLIC3R_DIR/slic3r.pl $archivefolder/slic3r.pl
 cp -fRP $SLIC3R_DIR/local-lib $archivefolder/local-lib
 cp -fRP $SLIC3R_DIR/lib/* $archivefolder/local-lib/lib/perl5/
 
-mkdir $archivefolder/bin
-echo "Installing libraries to $archivefolder/bin ..."
-if [ -z ${WXDIR+x} ]; then
-    for bundle in $(find $archivefolder/local-lib/lib/perl5 -name '*.so' | grep "Wx") $(find $archivefolder/local-lib/lib/perl5 -name '*.so' -type f | grep "wxWidgets"); do
-        echo "$(LD_LIBRARY_PATH=$libdirs ldd $bundle | grep .so | grep local-lib | awk '{print $3}')"
-        for dylib in $(LD_LIBRARY_PATH=$libdirs ldd $bundle | grep .so | grep local-lib | awk '{print $3}'); do
-            install -v $dylib $archivefolder/bin
-        done
-    done
-else
-    echo "Copying libraries from $WXDIR/lib to $archivefolder/bin"
-    for dylib in $(find $WXDIR/lib | grep "so"); do
-        cp -P -v $dylib $archivefolder/bin
-    done
-fi
-
 echo "Copying startup script..."
 cp -f $WD/startup_script.sh $archivefolder/$appname
 chmod +x $archivefolder/$appname

--- a/package/linux/slic3r.desktop.in
+++ b/package/linux/slic3r.desktop.in
@@ -1,13 +1,10 @@
 [Desktop Entry]
-
+Encoding=UTF-8
+Terminal=false
 Type=Application
-
 Version=SLIC3R_VERSION
-
 Name=APPLICATION_NAME
-
 Comment=Prepare 3D Models for printing
-
 Icon=slic3r
-
 Exec=Slic3r
+Categories=Engineering;Science;Graphics

--- a/package/linux/startup_script.sh
+++ b/package/linux/startup_script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 DIR=$(dirname "$0")
-export LD_LIBRARY_PATH=./shlib/x86_64-linux-thread-multi/
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}./shlib/x86_64-linux-thread-multi/
 exec "$DIR/perl-local" -I"$DIR/local-lib/lib/perl5" "$DIR/slic3r.pl" $@


### PR DESCRIPTION
Removes some duplicate libraries in the archive.