### PR TITLE
single line fix for #3862

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -804,6 +804,7 @@ sub add {
     
     my @input_files = wxTheApp->open_model($self);
     $self->load_file($_) for @input_files;
+	$self->on_model_change;
 }
 
 sub add_tin {


### PR DESCRIPTION
This line is present in all object related function (remove(), [de|in]crease(), mirror(), etc...) but seems to be missing in the add() function, fix the #3862 issue at least on my PC (I still need to test on my linuxes but I'm pretty confident)

And as long as I tested, it didn't introduce any unwanted behaviour.

