### PR TITLE
Implemented feature request #1405 minimum shell thickness option

### DIFF
--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -253,11 +253,8 @@ sub validate {
         die "Can't make less than one perimeter when spiral vase mode is enabled\n"
             if $self->perimeters < 1;
 
-        #my $max_nozzle_diameter = max(@{ $self->nozzle_diameter });
-        #die "Can't have a shell thicker than 1 perimiter when spiral vase mode is enabled\n"
-        #    if defined first { $self->min_shell_thickness > $max_nozzle_diameter }
-        #        map $self->get_abs_value_over("${_}_extrusion_width", $max_nozzle_diameter),
-        #        qw(perimeter external_perimeter);
+        die "Minimum shell thickness should be 0 when spiral vase mode is enabled\n"
+            if $self->min_shell_thickness > 0;
 
         die "Spiral vase mode can only print hollow objects, so you need to set Fill density to 0\n"
             if $self->fill_density > 0;

--- a/lib/Slic3r/Config.pm
+++ b/lib/Slic3r/Config.pm
@@ -172,6 +172,9 @@ sub validate {
     die "Invalid value for --filament-diameter\n"
         if grep $_ < 1, @{$self->filament_diameter};
     
+    die "Invalid value for --min-shell-thickness\n"
+        if $self->min_shell_thickness < 0;
+
     # --nozzle-diameter
     die "Invalid value for --nozzle-diameter\n"
         if grep $_ < 0, @{$self->nozzle_diameter};
@@ -249,7 +252,13 @@ sub validate {
         
         die "Can't make less than one perimeter when spiral vase mode is enabled\n"
             if $self->perimeters < 1;
-        
+
+        #my $max_nozzle_diameter = max(@{ $self->nozzle_diameter });
+        #die "Can't have a shell thicker than 1 perimiter when spiral vase mode is enabled\n"
+        #    if defined first { $self->min_shell_thickness > $max_nozzle_diameter }
+        #        map $self->get_abs_value_over("${_}_extrusion_width", $max_nozzle_diameter),
+        #        qw(perimeter external_perimeter);
+
         die "Spiral vase mode can only print hollow objects, so you need to set Fill density to 0\n"
             if $self->fill_density > 0;
         

--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -407,7 +407,7 @@ sub options {
     return qw(
         layer_height first_layer_height
         perimeters spiral_vase
-        top_solid_layers bottom_solid_layers
+        top_solid_layers min_shell_thickness bottom_solid_layers
         extra_perimeters avoid_crossing_perimeters thin_walls overhangs
         seam_position external_perimeters_first
         fill_density fill_pattern top_infill_pattern bottom_infill_pattern fill_gaps
@@ -485,6 +485,7 @@ sub build {
         {
             my $optgroup = $page->new_optgroup('Vertical shells');
             $optgroup->append_single_option_line('perimeters');
+            $optgroup->append_single_option_line('min_shell_thickness');
             $optgroup->append_single_option_line('spiral_vase');
         }
         {
@@ -759,10 +760,11 @@ sub _update {
     
     my $config = $self->{config};
     
-    if ($config->spiral_vase && !($config->perimeters == 1 && $config->top_solid_layers == 0 && $config->fill_density == 0 && $config->support_material == 0)) {
+    if ($config->spiral_vase && !($config->perimeters == 1 && $config->min_shell_thickness <= $config->external_perimeter_extrusion_width && $config->top_solid_layers == 0 && $config->fill_density == 0 && $config->support_material == 0)) {
         my $dialog = Wx::MessageDialog->new($self,
             "The Spiral Vase mode requires:\n"
             . "- one perimeter\n"
+            . "- a shell thickness no larger than the extrusion width\n"
             . "- no top solid layers\n"
             . "- 0% fill density\n"
             . "- no support material\n"
@@ -771,6 +773,7 @@ sub _update {
         if ($dialog->ShowModal() == wxID_YES) {
             my $new_conf = Slic3r::Config->new;
             $new_conf->set("perimeters", 1);
+            $new_conf->set("min_shell_thickness", 0);
             $new_conf->set("top_solid_layers", 0);
             $new_conf->set("fill_density", 0);
             $new_conf->set("support_material", 0);

--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -760,11 +760,11 @@ sub _update {
     
     my $config = $self->{config};
     
-    if ($config->spiral_vase && !($config->perimeters == 1 && $config->min_shell_thickness <= $config->external_perimeter_extrusion_width && $config->top_solid_layers == 0 && $config->fill_density == 0 && $config->support_material == 0)) {
+    if ($config->spiral_vase && !($config->perimeters == 1 && $config->min_shell_thickness == 0  && $config->top_solid_layers == 0 && $config->fill_density == 0 && $config->support_material == 0)) {
         my $dialog = Wx::MessageDialog->new($self,
             "The Spiral Vase mode requires:\n"
             . "- one perimeter\n"
-            . "- a shell thickness no larger than the extrusion width\n"
+            . "- shell thickness to be 0\n"
             . "- no top solid layers\n"
             . "- 0% fill density\n"
             . "- no support material\n"

--- a/t/perimeters.t
+++ b/t/perimeters.t
@@ -1,4 +1,4 @@
-use Test::More tests => 59;
+use Test::More tests => 60;
 use strict;
 use warnings;
 
@@ -311,6 +311,40 @@ use Slic3r::Test;
         }
     });
     ok !(grep { $_ % $config->perimeters } values %perimeters), 'no superfluous extra perimeters';
+}
+
+{
+    my $config = Slic3r::Config->new_from_defaults;
+    $config->set('skirts', 0);
+    $config->set('perimeters', 3);
+    $config->set('min_shell_thickness', 3);
+    $config->set('layer_height', 0.4);
+    $config->set('first_layer_height', 0.35);
+    $config->set('extra_perimeters', 0);
+    $config->set('first_layer_extrusion_width', 0.5);
+    $config->set('perimeter_extrusion_width', 0.5);
+    $config->set('external_perimeter_extrusion_width', 0.5);
+    $config->set('cooling', 0);                     # to prevent speeds from being altered
+    $config->set('first_layer_speed', '100%');      # to prevent speeds from being altered
+    $config->set('perimeter_speed', 99);
+    $config->set('external_perimeter_speed', 99);
+    $config->set('small_perimeter_speed', 99);
+    $config->set('thin_walls', 0);
+    
+    my $print = Slic3r::Test::init_print('ipadstand', config => $config);
+    my %perimeters = ();  # z => number of loops
+    my $in_loop = 0;
+    Slic3r::GCode::Reader->new->parse(Slic3r::Test::gcode($print), sub {
+        my ($self, $cmd, $args, $info) = @_;
+        
+        if ($info->{extruding} && $info->{dist_XY} > 0 && ($args->{F} // $self->F) == $config->perimeter_speed*60) {
+            $perimeters{$self->Z}++ if !$in_loop;
+            $in_loop = 1;
+        } else {
+            $in_loop = 0;
+        }
+    });
+    ok !(grep { $_ % $config->min_shell_thickness/$config->perimeter_extrusion_width } values %perimeters), 'should be 6 perimeters';
 }
 
 {

--- a/xs/src/libslic3r/PerimeterGenerator.cpp
+++ b/xs/src/libslic3r/PerimeterGenerator.cpp
@@ -6,6 +6,23 @@
 
 namespace Slic3r {
 
+int
+PerimeterGenerator::num_loops(int perimeters, int extra_perimeters) {
+    int generated_perimeters = perimeters + extra_perimeters - 1;
+    long int min_shell_thickness, shell_thickness = 0;
+
+    min_shell_thickness = this->config->min_shell_thickness * 1000000;
+    shell_thickness += this->ext_perimeter_flow.scaled_width();
+    shell_thickness += ((perimeters+extra_perimeters)-1) * this->perimeter_flow.scaled_width();
+    
+    if (shell_thickness < min_shell_thickness) {
+        shell_thickness = min_shell_thickness - this->ext_perimeter_flow.scaled_width();
+        generated_perimeters = ceil((float)shell_thickness/this->ext_perimeter_flow.scaled_width());
+    }
+
+    return generated_perimeters;
+}
+
 void
 PerimeterGenerator::process()
 {
@@ -54,7 +71,7 @@ PerimeterGenerator::process()
     for (Surfaces::const_iterator surface = this->slices->surfaces.begin();
         surface != this->slices->surfaces.end(); ++surface) {
         // detect how many perimeters must be generated for this island
-        const int loop_number = this->config->perimeters + surface->extra_perimeters -1;  // 0-indexed loops
+        const int loop_number = num_loops(this->config->perimeters, surface->extra_perimeters);//this->config->perimeters + surface->extra_perimeters-1;  // 0-indexed loops
         
         Polygons gaps;
         

--- a/xs/src/libslic3r/PerimeterGenerator.hpp
+++ b/xs/src/libslic3r/PerimeterGenerator.hpp
@@ -88,6 +88,7 @@ public:
         ThickPolylines &thin_walls) const;
     ExtrusionEntityCollection _variable_width
         (const ThickPolylines &polylines, ExtrusionRole role, Flow flow) const;
+    int num_loops(int perimeters, int extra_perimeters);
 };
 
 }

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -775,6 +775,15 @@ PrintConfigDef::PrintConfigDef()
     def->max = 100;
     def->default_value = new ConfigOptionInt(35);
 
+    def = this->add("min_shell_thickness", coFloat);
+    def->label = "Minimum shell thickness";
+    def->category = "Layers and Perimeters";
+    def->sidetext = "mm";
+    def->tooltip = "Minimum shell thickness in mm";
+    def->cli = "min-shell-thickness=f";
+    def->min = 0;
+    def->default_value = new ConfigOptionFloat(0);
+
     def = this->add("min_print_speed", coFloat);
     def->label = "Min print speed";
     def->tooltip = "Slic3r will not scale speed down below this speed.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -225,6 +225,7 @@ class PrintRegionConfig : public virtual StaticPrintConfig
     ConfigOptionInt                 infill_every_layers;
     ConfigOptionFloatOrPercent      infill_overlap;
     ConfigOptionFloat               infill_speed;
+    ConfigOptionFloat               min_shell_thickness;
     ConfigOptionBool                overhangs;
     ConfigOptionInt                 perimeter_extruder;
     ConfigOptionFloatOrPercent      perimeter_extrusion_width;
@@ -266,6 +267,7 @@ class PrintRegionConfig : public virtual StaticPrintConfig
         OPT_PTR(infill_every_layers);
         OPT_PTR(infill_overlap);
         OPT_PTR(infill_speed);
+        OPT_PTR(min_shell_thickness);
         OPT_PTR(overhangs);
         OPT_PTR(perimeter_extruder);
         OPT_PTR(perimeter_extrusion_width);


### PR DESCRIPTION
This adds a new print config option, minimum shell thickness. It works as described in the issue page by alexrj. The current configuration, when paired with the generate extra perimeters option, will only add perimeters when both the normal and extra perimeters combined don't meet the shell thickness requirements.