### PR TITLE
Command line help for --datadir option

### DIFF
--- a/slic3r.pl
+++ b/slic3r.pl
@@ -316,6 +316,9 @@ Usage: slic3r.pl [ OPTIONS ] [ file.stl ] [ file2.stl ] ...
     --save <file>       Save configuration to the specified file
     --load <file>       Load configuration from the specified file. It can be used 
                         more than once to load options from multiple files.
+    --datadir <path>    Load and store settings at the given directory.
+                        This is useful for maintaining different profiles or including
+                        configurations from a network storage.
     -o, --output <file> File to output gcode to (by default, the file will be saved
                         into the same directory as the input file using the
                         --output-filename-format to generate the filename.) If a


### PR DESCRIPTION
I frequently use the --datadir option to maintain different profiles or test settings from other people and have to point people to the [documentation](http://manual.slic3r.org/configuration-organization/configuration-organization) because the option is not listed in the command line info and most people don't know about it.

This PR only adds a short description of this option.