### PR TITLE
Disable Plater menu when there are no objects in plater

### DIFF
--- a/lib/Slic3r/GUI/MainFrame.pm
+++ b/lib/Slic3r/GUI/MainFrame.pm
@@ -194,6 +194,7 @@ sub _init_menubar {
         }, undef, 'brick_go.png');
         
         $self->{object_menu} = $self->{plater}->object_menu;
+        $self->on_plater_object_list_changed(0);
         $self->on_plater_selection_changed(0);
     }
     
@@ -307,6 +308,14 @@ sub _init_menubar {
 sub is_loaded {
     my ($self) = @_;
     return $self->{loaded};
+}
+
+sub on_plater_object_list_changed {
+    my ($self, $have_objects) = @_;
+    
+    return if !defined $self->{plater_menu};
+    $self->{plater_menu}->Enable($_->GetId, $have_objects)
+        for $self->{plater_menu}->GetMenuItems;
 }
 
 sub on_plater_selection_changed {

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -2169,6 +2169,9 @@ sub object_list_changed {
         $self->{htoolbar}->EnableTool($_, $have_objects)
             for (TB_RESET, TB_ARRANGE);
     }
+    
+    # prepagate the event to the frame (a custom Wx event would be cleaner)
+    $self->GetFrame->on_plater_object_list_changed($have_objects);
 }
 
 sub selection_changed {


### PR DESCRIPTION
Plater menu has no sense to be enabled when there are no objects in plater, so this patch enable/disable it when objects list is changed.