### PR TITLE
Enhance scrolling by using font point size as scroll rate

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -101,6 +101,10 @@ our $medium_font = Wx::SystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
 $medium_font->SetPointSize(12);
 our $grey = Wx::Colour->new(200,200,200);
 
+# to use in ScrolledWindow::SetScrollRate(xstep, ystep)
+# step related to system font point size
+our $scroll_step = Wx::SystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT)->GetPointSize;
+
 our $VERSION_CHECK_EVENT : shared = Wx::NewEventType;
 
 our $DLP_projection_screen;

--- a/lib/Slic3r/GUI/Plater/OverrideSettingsPanel.pm
+++ b/lib/Slic3r/GUI/Plater/OverrideSettingsPanel.pm
@@ -89,7 +89,9 @@ sub new {
     }
     
     $self->SetSizer($self->{sizer});
-    $self->SetScrollbars(0, 1, 0, 1);
+    
+    # http://docs.wxwidgets.org/3.0/classwx_scrolled.html#details
+    $self->SetScrollRate(0, $Slic3r::GUI::scroll_step);
     
     $self->set_opt_keys($params{opt_keys}) if $params{opt_keys};
     $self->update_optgroup;

--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -1602,10 +1602,11 @@ sub new {
     $self->{title}      = $title;
     $self->{iconID}     = $iconID;
     
-    $self->SetScrollbars(1, 1, 1, 1);
-    
     $self->{vsizer} = Wx::BoxSizer->new(wxVERTICAL);
     $self->SetSizer($self->{vsizer});
+    
+    # http://docs.wxwidgets.org/3.0/classwx_scrolled.html#details
+    $self->SetScrollRate($Slic3r::GUI::scroll_step, $Slic3r::GUI::scroll_step);
     
     return $self;
 }


### PR DESCRIPTION
In wxWidgets documentation there are three ways to set the size of the
scrolling area. The most automatic (and newest) way is by using SetScrollRate:
  * http://docs.wxwidgets.org/trunk/classwx_scrolled.html#details

Also, change the anoying behavior of 1px per mouse step, which makes scrolling eternal, with a more comfortable font size related step rate.

It works as expected in GNU/Linux platform. Testing in Mac/Windows are welcome.