### PR TITLE
Skip event handling in 3D/Layer preview tab when no UP or DOWN key is pressed

### DIFF
--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -60,6 +60,8 @@ sub new {
         } elsif ($key == 68 || $key == 317) {
             $slider->SetValue($slider->GetValue - 1);
             $self->set_z($self->{layers_z}[$slider->GetValue]);
+        } else {
+            $event->Skip;
         }
     });
     

--- a/lib/Slic3r/GUI/Plater/3DPreview.pm
+++ b/lib/Slic3r/GUI/Plater/3DPreview.pm
@@ -58,6 +58,8 @@ sub new {
         } elsif ($key == 68 || $key == 317) {
             $slider->SetValue($slider->GetValue - 1);
             $self->set_z($self->{layers_z}[$slider->GetValue]);
+        } else {
+            $event->Skip;
         }
     });
     


### PR DESCRIPTION
Fixes #3792 by skipping event handling in  3D Preview and Layer tabs when no `UP` or `DOWN` key is pressend.