### PR TITLE
Link to libstdc++ statically.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: perl
 before_install:
 - sh package/linux/travis-decrypt-key
 install:
-- export LDLOADLIBS=-lstdc++
 - export BOOST_DIR=$HOME/boost_1_63_0
 - export SLIC3R_STATIC=1
 - export CXX=g++-4.9

--- a/package/deploy/sftp.sh
+++ b/package/deploy/sftp.sh
@@ -19,9 +19,14 @@ fi
 if [ -s $KEY ]; then
     for i in $FILES; do 
          filepath=$(readlink -f "$i")
-         echo put $filepath | sftp -b - -i$KEY "${UPLOAD_USER}@dl.slic3r.org:$DIR/"
+         tmpfile=$(mktemp)
+         echo put $filepath > $tmpfile 
+         sftp -b $tmpfile -i$KEY "${UPLOAD_USER}@dl.slic3r.org:$DIR/"
          result=$?
-         if [ $? -eq 1 ]; then exit $result; fi
+         if [ $? -eq 1 ]; then 
+             echo "Error with SFTP"
+             exit $result; 
+         fi
     done
 else
     echo "$KEY is not available, not deploying." 

--- a/package/deploy/sftp.sh
+++ b/package/deploy/sftp.sh
@@ -19,8 +19,11 @@ fi
 if [ -s $KEY ]; then
     for i in $FILES; do 
          filepath=$(readlink -f "$i")
-         echo put $filepath | sftp -i$KEY "${UPLOAD_USER}@dl.slic3r.org:$DIR/"
+         echo put $filepath | sftp -b - -i$KEY "${UPLOAD_USER}@dl.slic3r.org:$DIR/"
+         result=$?
+         if [ $? -eq 1 ]; then exit $result; fi
     done
 else
     echo "$KEY is not available, not deploying." 
 fi
+exit $result

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -35,7 +35,12 @@ if (`$Config{cc} -v` =~ /gcc version 4\.6\./) {
 my @ldflags = ();
 
 if ($linux && (defined $ENV{SLIC3R_STATIC} && $ENV{SLIC3R_STATIC})) {
-    push @ldflags, qw(-static-libgcc -static-libstdc++);
+    if ($ENV{TRAVIS}) {
+        # On the build server, link to the actual static libraries.
+    	push @ldflags, qw(/usr/lib/gcc/x86_64-linux-gnu/4.9/libstdc++.a /usr/lib/gcc/x86_64-linux-gnu/4.9/libgcc.a);
+    } else {
+        push @ldflags, qw(-static-libgcc -static-libstdc++);
+    }
 }
 
 if ($^O eq 'darwin') {

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -25,21 +25,16 @@ if ($cpp_guess->is_gcc)	{
 	push @cflags, qw(-U__STRICT_ANSI__);
 }
 
-if (`$Config{cc} -v` =~ /gcc version 4\.6\./) {
-    # Compatibility with GCC 4.6 is not a requirement, but as long as code compiles on it we try to support it.
-    push @cflags, qw(-std=c++0x);
-} else {
-    # std=c++11 Enforce usage of C++11 (required now). Minimum compiler supported: gcc 4.9, clang 3.3, MSVC 14.0
-    push @cflags, qw(-std=c++11);
-}
+# std=c++11 Enforce usage of C++11 (required now). Minimum compiler supported: gcc 4.9, clang 3.3, MSVC 14.0
+push @cflags, qw(-std=c++11);
+
 my @ldflags = ();
 
 if ($linux && (defined $ENV{SLIC3R_STATIC} && $ENV{SLIC3R_STATIC})) {
+    push @ldflags, qw(-static-libgcc -static-libstdc++);
     if ($ENV{TRAVIS}) {
-        # On the build server, link to the actual static libraries.
+        # On the build server, link to the actual static libraries to make sure we get them in the list.
     	push @ldflags, qw(/usr/lib/gcc/x86_64-linux-gnu/4.9/libstdc++.a /usr/lib/gcc/x86_64-linux-gnu/4.9/libgcc.a);
-    } else {
-        push @ldflags, qw(-static-libgcc -static-libstdc++);
     }
 }
 

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -36,6 +36,18 @@ if ($linux && (defined $ENV{SLIC3R_STATIC} && $ENV{SLIC3R_STATIC})) {
         # On the build server, link to the actual static libraries to make sure we get them in the list.
     	push @ldflags, qw(/usr/lib/gcc/x86_64-linux-gnu/4.9/libstdc++.a /usr/lib/gcc/x86_64-linux-gnu/4.9/libgcc.a);
     }
+    # ExtUtils::CppGuess has a hard-coded -lstdc++, so we filter it out
+    {
+        no strict 'refs';
+        no warnings 'redefine';
+        my $func = "ExtUtils::CppGuess::_get_lflags";
+        my $orig = *$func{CODE};
+        *{$func} = sub {
+            my $lflags = $orig->(@_);
+            $lflags =~ s/\s*-lstdc\+\+//;
+            return $lflags;
+        };
+    }
 }
 
 if ($^O eq 'darwin') {

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -10,6 +10,7 @@ use Module::Build::WithXSpp;
 
 my $cpp_guess = ExtUtils::CppGuess->new;
 my $mswin = $^O eq 'MSWin32';
+my $linux = $^O eq 'linux';
 
 # prevent an annoying concatenation warning by Devel::CheckLib
 $ENV{LD_RUN_PATH} //= "";
@@ -18,11 +19,12 @@ $ENV{LD_RUN_PATH} //= "";
 # HAS_BOOL         : stops Perl/lib/CORE/handy.h from doing "#  define bool char" for MSVC
 # NOGDI            : prevents inclusion of wingdi.h which defines functions Polygon() and Polyline() in global namespace
 # BOOST_ASIO_DISABLE_KQUEUE : prevents a Boost ASIO bug on OS X: https://svn.boost.org/trac/boost/ticket/5339
-my @cflags = qw(-static-libstdc++ -D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
+my @cflags = qw(-D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
 if ($cpp_guess->is_gcc)	{
 	# GCC is pedantic with c++11 std, so undefine strict ansi to get M_PI back
 	push @cflags, qw(-U__STRICT_ANSI__);
 }
+
 if (`$Config{cc} -v` =~ /gcc version 4\.6\./) {
     # Compatibility with GCC 4.6 is not a requirement, but as long as code compiles on it we try to support it.
     push @cflags, qw(-std=c++0x);
@@ -31,6 +33,9 @@ if (`$Config{cc} -v` =~ /gcc version 4\.6\./) {
     push @cflags, qw(-std=c++11);
 }
 my @ldflags = ();
+if ($linux) {
+    push @ldflags, qw(-static-libgcc -static-libstdc++);
+}
 if ($^O eq 'darwin') {
     push @cflags, qw(-stdlib=libc++);
     push @ldflags, qw(-framework IOKit -framework CoreFoundation -lc++);

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -33,9 +33,11 @@ if (`$Config{cc} -v` =~ /gcc version 4\.6\./) {
     push @cflags, qw(-std=c++11);
 }
 my @ldflags = ();
-if ($linux) {
+
+if ($linux && (defined $ENV{SLIC3R_STATIC} && $ENV{SLIC3R_STATIC})) {
     push @ldflags, qw(-static-libgcc -static-libstdc++);
 }
+
 if ($^O eq 'darwin') {
     push @cflags, qw(-stdlib=libc++);
     push @ldflags, qw(-framework IOKit -framework CoreFoundation -lc++);

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -202,14 +202,6 @@ if ($ENV{SLIC3R_DEBUG}) {
     push @cflags, '-DNDEBUG';
 }
 if ($cpp_guess->is_gcc) {
-    # check whether we're dealing with a buggy GCC version
-    # see https://github.com/alexrj/Slic3r/issues/1965
-    if (`cc --version` =~ / 4\.7\.[012]/) {
-        # Workaround suggested by Boost devs:
-        # https://svn.boost.org/trac/boost/ticket/8695
-        push @cflags, qw(-fno-inline-small-functions);
-    }
-    
     # our templated XS bindings cause undefined-var-template warnings
     push @cflags, qw(-Wno-undefined-var-template);
 }

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -18,7 +18,7 @@ $ENV{LD_RUN_PATH} //= "";
 # HAS_BOOL         : stops Perl/lib/CORE/handy.h from doing "#  define bool char" for MSVC
 # NOGDI            : prevents inclusion of wingdi.h which defines functions Polygon() and Polyline() in global namespace
 # BOOST_ASIO_DISABLE_KQUEUE : prevents a Boost ASIO bug on OS X: https://svn.boost.org/trac/boost/ticket/5339
-my @cflags = qw(-D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
+my @cflags = qw(-static-libstdc++ -D_GLIBCXX_USE_C99 -DHAS_BOOL -DNOGDI -DSLIC3RXS -DBOOST_ASIO_DISABLE_KQUEUE);
 if ($cpp_guess->is_gcc)	{
 	# GCC is pedantic with c++11 std, so undefine strict ansi to get M_PI back
 	push @cflags, qw(-U__STRICT_ANSI__);


### PR DESCRIPTION
Attempting to link to libstdc++ statically to deal with relatively ancient systems (see: opensuse 13.2) which are never getting a more modern compiler than GCC 4.8.

@azalanono Fixes #4015