### PR TITLE
Fix host_type comparison when sending G-code to octoprint

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1852,7 +1852,7 @@ sub send_gcode {
     my $filename = basename($self->{print}->output_filepath($main::opt{output} // ''));
     my $res;
     if($self->{config}->print_host){
-        if($self->{config}->host_type eq 'Octoprint'){
+        if($self->{config}->host_type eq 'octoprint'){
             $res = $ua->post(
                 "http://" . $self->{config}->print_host . "/api/files/local",
                 Content_Type => 'form-data',


### PR DESCRIPTION
`host_type` values are lowercase. This fixes a 404 error (because it attempts to
upload to /rr_upload) when sending G-code to Octoprint.