### PR TITLE
Refactor out the perl packages into a common file.

### DIFF
--- a/package/common/coreperl
+++ b/package/common/coreperl
@@ -1,0 +1,21 @@
+# Core perl modules used in Slic3r
+attributes
+base
+bytes
+B
+POSIX
+FindBin 
+Unicode::Normalize 
+Tie::Handle
+Time::Local 
+Math::Trig 
+IO::Socket 
+Errno
+Storable 
+lib 
+overload
+warnings 
+local::lib
+strict 
+utf8 
+parent

--- a/package/linux/make_archive.sh
+++ b/package/linux/make_archive.sh
@@ -92,15 +92,10 @@ cp -f $WD/startup_script.sh $archivefolder/$appname
 chmod +x $archivefolder/$appname
 
 echo "Copying perl from $PERL_BIN"
+# Edit package/common/coreperl to add/remove core Perl modules added to this package, one per line.
 cp -f $PERL_BIN $archivefolder/perl-local
 ${PP_BIN} wxextension .0 \
-	  -M attributes -M base -M bytes -M B -M POSIX \
-          -M FindBin -M Unicode::Normalize -M Tie::Handle \
-          -M Time::Local -M Math::Trig -M IO::Socket -M Errno \
-          -M Storable \
-          -M lib -M overload \
-          -M warnings -M local::lib \
-          -M strict -M utf8 -M parent \
+	  -M $(grep -v "^#" ${WD}/../common/coreperl | xargs | awk 'BEGIN { OFS=" -M "}; {$1=$1; print $0}') \
           -B -p -e "print 123" -o $WD/_tmp/test.par
 unzip -qq -o $WD/_tmp/test.par -d $WD/_tmp/
 cp -rf $WD/_tmp/lib/* $archivefolder/local-lib/lib/perl5/

--- a/package/osx/make_dmg.sh
+++ b/package/osx/make_dmg.sh
@@ -98,13 +98,10 @@ cp -f $WD/startup_script.sh $macosfolder/$appname
 chmod +x $macosfolder/$appname
 
 echo "Copying perl from $PERL_BIN"
+# Edit package/common/coreperl to add/remove core Perl modules added to this package, one per line.
 cp -f $PERL_BIN $macosfolder/perl-local
-${PP_BIN} -M attributes -M base -M bytes -M B -M POSIX \
-          -M FindBin -M Unicode::Normalize -M Tie::Handle \
-          -M Time::Local -M Math::Trig -M IO::Socket -M Errno \
-          -M Storable -M lib -M overload \
-          -M warnings -M local::lib \
-          -M strict -M utf8 -M parent \
+${PP_BIN} \
+          -M $(grep -v "^#" ${WD}/../common/coreperl | xargs | awk 'BEGIN { OFS=" -M "}; {$1=$1; print $0}') \
           -B -p -e "print 123" -o $WD/_tmp/test.par
 unzip -o $WD/_tmp/test.par -d $WD/_tmp/
 cp -rf $WD/_tmp/lib/* $macosfolder/local-lib/lib/perl5/


### PR DESCRIPTION
Linux builds broke for a while because Storable wasn't necessarily available. So let's move the core perl modules we're packaging to one list instead of two (DRY).