### PR TITLE
Fix first object layer height when raft is on

### DIFF
--- a/t/combineinfill.t
+++ b/t/combineinfill.t
@@ -43,9 +43,11 @@ plan tests => 8;
         my $layers_with_infill = grep $_ > 0,  values %layer_infill;
         is scalar(keys %layers), $layers_with_perimeters+$config->raft_layers, 'expected number of layers';
         
-        # first infill layer is never combined, so we don't consider it
-        $layers_with_infill--;
-        $layers_with_perimeters--;
+        if ($config->raft_layers == 0) {
+            # first infill layer is not combined when raft is off, so we don't consider it
+            $layers_with_infill--;
+            $layers_with_perimeters--;
+        }
         
         # we expect that infill is generated for half the number of combined layers
         # plus for each single layer that was not combined (remainder)

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -647,15 +647,8 @@ void PrintObject::_slice()
         raft_height += first_layer_height;
         raft_height += support_material_layer_height * (this->config.raft_layers - 1);
 
-        // reset for later layer generation
-        first_layer_height = 0;
-
-        // detachable support
-        if(this->config.support_material_contact_distance > 0) {
-            first_layer_height = min_support_nozzle_diameter;
-            raft_height += this->config.support_material_contact_distance;
-
-        }
+        first_layer_height = this->config.layer_height.value;
+        raft_height += this->config.support_material_contact_distance;
     }
 
     // Initialize layers and their slice heights.


### PR DESCRIPTION
When raft is on, first object layer should be equal to `layer_height` rather than `first_layer_height` or `min_support_nozzle_diameter ` which causes wrong contact distance calculation for the raft layer.