### PR TITLE
Fix some cli arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Contributions by Henrik Brix Andersen, Vojtech Bubnik, Nicolas Dandrimont, Mark 
                             print rather than processed individually.
     
       Printer options:
+        --bed-shape         Coordinates in mm of the bed's points (default: 0x0,200x0,200x200,0x200)
         --nozzle-diameter   Diameter of nozzle in mm (default: 0.5)
         --print-center      Coordinates in mm of the point to center the print around
                             (default: 100,100)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Contributions by Henrik Brix Andersen, Vojtech Bubnik, Nicolas Dandrimont, Mark 
     
       Printer options:
         --bed-shape         Coordinates in mm of the bed's points (default: 0x0,200x0,200x200,0x200)
+        --has-heatbed       This will provide automatic generation of bed heating gcode
         --nozzle-diameter   Diameter of nozzle in mm (default: 0.5)
         --print-center      Coordinates in mm of the point to center the print around
                             (default: 100,100)

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -45,7 +45,7 @@ PrintConfigDef::PrintConfigDef()
     def = this->add("has_heatbed", coBool);
     def->label = "Has heated bed";
     def->tooltip = "Unselecting this will suppress automatic generation of bed heating gcode.";
-    def->cli = "has_heatbed!";
+    def->cli = "has-heatbed!";
     def->default_value = new ConfigOptionBool(true);
     
     def = this->add("bed_temperature", coInt);

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -40,6 +40,8 @@ PrintConfigDef::PrintConfigDef()
         opt->values.push_back(Pointf(0,200));
         def->default_value = opt;
     }
+    def->cli = "bed-shape=s";
+
     def = this->add("has_heatbed", coBool);
     def->label = "Has heated bed";
     def->tooltip = "Unselecting this will suppress automatic generation of bed heating gcode.";


### PR DESCRIPTION
This PR contains these fixes:

- add `--bed-shape` cli argument and add it to the doc
- make `--has-heatbed` compatible with other cli arguments and add it to the doc.