### PR TITLE
New configuration for support material interface extrusion width

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -471,7 +471,7 @@ sub options {
         extrusion_width first_layer_extrusion_width perimeter_extrusion_width 
         external_perimeter_extrusion_width infill_extrusion_width solid_infill_extrusion_width 
         top_infill_extrusion_width support_material_extrusion_width
-        infill_overlap bridge_flow_ratio
+        support_material_interface_extrusion_width infill_overlap bridge_flow_ratio
         xy_size_compensation resolution shortcuts compatible_printers
         print_settings_id
     )
@@ -680,7 +680,8 @@ sub build {
                 for qw(extrusion_width first_layer_extrusion_width
                     perimeter_extrusion_width external_perimeter_extrusion_width
                     infill_extrusion_width solid_infill_extrusion_width
-                    top_infill_extrusion_width support_material_extrusion_width);
+                    top_infill_extrusion_width support_material_interface_extrusion_width 
+                    support_material_extrusion_width);
         }
         {
             my $optgroup = $page->new_optgroup('Overlap');
@@ -912,7 +913,8 @@ sub _update {
         for qw(support_material_threshold support_material_pattern 
             support_material_spacing support_material_angle
             support_material_interface_layers dont_support_bridges
-            support_material_extrusion_width support_material_contact_distance);
+            support_material_extrusion_width support_material_interface_extrusion_width
+            support_material_contact_distance);
 
     $self->get_field($_)->toggle($have_support_material && $have_support_interface)
         for qw(support_material_interface_spacing support_material_interface_extruder

--- a/lib/Slic3r/Print/Object.pm
+++ b/lib/Slic3r/Print/Object.pm
@@ -670,11 +670,16 @@ sub support_material_flow {
     my $extruder = ($role == FLOW_ROLE_SUPPORT_MATERIAL)
         ? $self->config->support_material_extruder
         : $self->config->support_material_interface_extruder;
+
+    my $width = $self->config->support_material_extrusion_width || $self->config->extrusion_width;
+    if ($role == FLOW_ROLE_SUPPORT_MATERIAL_INTERFACE) {
+        $width = $self->config->support_material_interface_extrusion_width || $width;
+    }
     
     # we use a bogus layer_height because we use the same flow for all
     # support material layers
     return Slic3r::Flow->new_from_width(
-        width               => $self->config->support_material_extrusion_width || $self->config->extrusion_width,
+        width               => $width,
         role                => $role,
         nozzle_diameter     => $self->print->config->nozzle_diameter->[$extruder-1] // $self->print->config->nozzle_diameter->[0],
         layer_height        => $self->config->layer_height,

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1381,6 +1381,18 @@ PrintConfigDef::PrintConfigDef()
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
+    def = this->add("support_material_interface_extrusion_width", coFloatOrPercent);
+    def->label = "Support material";
+    def->gui_type = "f_enum_open";
+    def->category = "Extrusion Width";
+    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for support material interface. If expressed as percentage (for example 90%) it will be computed over layer height.";
+    def->sidetext = "mm or %";
+    def->cli = "support-material-interface-extrusion-width=s";
+    def->min = 0;
+    def->enum_values.push_back("0");
+    def->enum_labels.push_back("default");
+    def->default_value = new ConfigOptionFloatOrPercent(0, false);
+
     def = this->add("support_material_interface_layers", coInt);
     def->label = "Interface layers";
     def->category = "Support material";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -171,6 +171,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     ConfigOptionInt                 support_material_extruder;
     ConfigOptionFloatOrPercent      support_material_extrusion_width;
     ConfigOptionInt                 support_material_interface_extruder;
+    ConfigOptionFloatOrPercent      support_material_interface_extrusion_width;
     ConfigOptionInt                 support_material_interface_layers;
     ConfigOptionFloat               support_material_interface_spacing;
     ConfigOptionFloatOrPercent      support_material_interface_speed;
@@ -203,6 +204,7 @@ class PrintObjectConfig : public virtual StaticPrintConfig
         OPT_PTR(support_material_extruder);
         OPT_PTR(support_material_extrusion_width);
         OPT_PTR(support_material_interface_extruder);
+        OPT_PTR(support_material_interface_extrusion_width);
         OPT_PTR(support_material_interface_layers);
         OPT_PTR(support_material_interface_spacing);
         OPT_PTR(support_material_interface_speed);

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -239,6 +239,7 @@ PrintObject::invalidate_state_by_config(const PrintConfigBase &config)
             || opt_key == "support_material_extrusion_width"
             || opt_key == "support_material_interface_layers"
             || opt_key == "support_material_interface_extruder"
+            || opt_key == "support_material_interface_extrusion_width"
             || opt_key == "support_material_interface_spacing"
             || opt_key == "support_material_interface_speed"
             || opt_key == "support_material_buildplate_only"


### PR DESCRIPTION
Currently, slic3r uses `support_material_extrusion_width` for interfaces. Assigning very low values to `support_material_extrusion_width` makes supports very easy to break which is very a good feature. But when `support_material_extrusion_width` is very low, interfaces don't stick to neither the lower support layers nor the adjacent extrusion lines.

So what I do is to define a new configuration parameter for support material interfaces, and I can still use very low values `support_material_extrusion_width` and higher values for support material interfaces for reliable extrusion. For example:

For `nozzle_diameter = 0.4`;
`support_material_extrusion_width = 0.4` makes the supports very thin and easy to break and
`support_material_interface_extrusion_width = 0.5` makes reliable and accurate extrusion lines for interfaces.

PR does not create any BC break, if the `support_material_interface_extrusion_width` is not defined, `support_material_extrusion_width` or `extrusion_width` will be used as the old behaviour.