### PR TITLE
Use constant speed for too short displacements

### DIFF
--- a/xs/src/libslic3r/GCodeTimeEstimator.cpp
+++ b/xs/src/libslic3r/GCodeTimeEstimator.cpp
@@ -66,12 +66,8 @@ GCodeTimeEstimator::_accelerated_move(double length, double v, double accelerati
     if (half_length >= dx_init) {
         half_length -= (0.5*v*t_init);
         t += t_init;
-        t += (half_length / v); // rest of time is at constant speed.
-    } else {
-        // If too much displacement for the expected final velocity, we don't hit the max, so reduce 
-        // the average velocity to fit the displacement we actually are looking for.
-        t += std::sqrt(std::abs(length) * 2.0 * acceleration) / acceleration;
     }
+    t += (half_length / v); // constant speed for rest of the time and too short displacements
     return 2.0*t; // cut in half before, so double to get full time spent.
 }
 


### PR DESCRIPTION
I have been testing time estimation for about a week, it works pretty accurate with small models but the estimation for big and rounded models are very far (sometimes for days) from the expected.

Because generally the rounded models (means lots of gcode for a single line) are inaccurate, it looks like short displacement time calculation does not work well. So I considered constant speed for too short displacements and the results are really promising.

Time estimation is much more complex than it seems but this PR improves it a little bit.