### PR TITLE
Added secondary libpaths to stick into appimage because reasons.

### DIFF
--- a/package/linux/appimage.sh
+++ b/package/linux/appimage.sh
@@ -41,6 +41,13 @@ mkdir -p ${WD}/${APP}.AppDir/usr/lib
 for i in $(ls $srcfolder/bin); do  
     install -v $srcfolder/bin/$i ${WD}/${APP}.AppDir/usr/lib
 done
+
+# copy other libraries needed to /usr/lib because this is an AppImage build.
+for i in $(cat $WD/libpaths.appimage.txt | grep -v "^#" | awk -F# '{print $1}'); do 
+    install -v $i ${WD}/${APP}.AppDir/usr/lib
+done
+
+
 cp -R $srcfolder/local-lib ${WD}/${APP}.AppDir/usr/lib/local-lib
 
 cat > $WD/${APP}.AppDir/AppRun << 'EOF'

--- a/package/linux/libpaths.appimage.txt
+++ b/package/linux/libpaths.appimage.txt
@@ -1,0 +1,1 @@
+/usr/lib/x86_64-linux-gnu/libstdc++.so.6 # needed because of ancient distros and slic3r (and perl for perl reasons) needs modern c++.


### PR DESCRIPTION
Stick libstdc++ with modern symbols/ABI in it to work around an issue where distros that can't be upgraded to use > gcc 4.9  can still use the AppImage (looking at you, OpenSUSE). 

In pursuit of #4015 