### PR TITLE
Long retract support in marlin and repetier for FW retract.

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -1557,6 +1557,25 @@ sub _update {
         
         # when using firmware retraction, firmware decides retraction length
         $self->get_field('retract_length', $i)->toggle(!$config->use_firmware_retraction);
+        if ($config->use_firmware_retraction && 
+            ($config->gcode_flavor eq 'reprap' || $config->gcode_flavor eq 'repetier') && 
+            ($config->get_at('retract_length_toolchange', $i) > 0 || $config->get_at('retract_restart_extra_toolchange', $i) > 0)) {
+            my $dialog = Wx::MessageDialog->new($self,
+                "Retract length for toolchange on extruder " . $i . " is not available when using the Firmware Retraction mode.\n"
+                . "\nShall I disable it in order to enable Firmware Retraction?",
+                'Firmware Retraction', wxICON_WARNING | wxYES | wxNO);
+            
+            my $new_conf = Slic3r::Config->new;
+            if ($dialog->ShowModal() == wxID_YES) {
+                my $retract_length_toolchange = $config->retract_length_toolchange;
+                $retract_length_toolchange->[$i] = 0;
+                $new_conf->set("retract_length_toolchange", $retract_length_toolchange);
+                $new_conf->set("retract_restart_extra_toolchange", $retract_length_toolchange);
+            } else {
+                $new_conf->set("use_firmware_retraction", 0);
+            }
+            $self->_load_config($new_conf);
+        }
         
         # user can customize travel length if we have retraction length or we're using
         # firmware retraction
@@ -1595,12 +1614,15 @@ sub _update {
             }
             $self->_load_config($new_conf);
         }
-        
-        $self->get_field('retract_length_toolchange', $i)->toggle($have_multiple_extruders);
+
+        $self->get_field('retract_length_toolchange', $i)->toggle
+            ($have_multiple_extruders && 
+            !($config->use_firmware_retraction && ($config->gcode_flavor eq 'reprap' || $config->gcode_flavor eq 'repetier')));
         
         my $toolchange_retraction = $config->get_at('retract_length_toolchange', $i) > 0;
         $self->get_field('retract_restart_extra_toolchange', $i)->toggle
-            ($have_multiple_extruders && $toolchange_retraction);
+            ($have_multiple_extruders && $toolchange_retraction && 
+            !($config->use_firmware_retraction && ($config->gcode_flavor eq 'reprap' || $config->gcode_flavor eq 'repetier')));
     }
 }
 

--- a/package/linux/appimage.sh
+++ b/package/linux/appimage.sh
@@ -41,6 +41,13 @@ mkdir -p ${WD}/${APP}.AppDir/usr/lib
 for i in $(ls $srcfolder/bin); do  
     install -v $srcfolder/bin/$i ${WD}/${APP}.AppDir/usr/lib
 done
+
+# copy other libraries needed to /usr/lib because this is an AppImage build.
+for i in $(cat $WD/libpaths.appimage.txt | grep -v "^#" | awk -F# '{print $1}'); do 
+    install -v $i ${WD}/${APP}.AppDir/usr/lib
+done
+
+
 cp -R $srcfolder/local-lib ${WD}/${APP}.AppDir/usr/lib/local-lib
 
 cat > $WD/${APP}.AppDir/AppRun << 'EOF'

--- a/package/linux/libpaths.appimage.txt
+++ b/package/linux/libpaths.appimage.txt
@@ -1,0 +1,1 @@
+/usr/lib/x86_64-linux-gnu/libstdc++.so.6 # needed because of ancient distros and slic3r (and perl for perl reasons) needs modern c++.

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -463,7 +463,7 @@ GCodeWriter::retract_for_toolchange()
 }
 
 std::string
-GCodeWriter::_retract(double length, double restart_extra, const std::string &comment, bool long_retract = false)
+GCodeWriter::_retract(double length, double restart_extra, const std::string &comment, bool long_retract)
 {
     std::ostringstream gcode;
     

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -485,7 +485,7 @@ GCodeWriter::_retract(double length, double restart_extra, const std::string &co
         if (this->config.use_firmware_retraction) {
             if (FLAVOR_IS(gcfMachinekit))
                 gcode << "G22";
-            else if ((FLAVOR_IS(gcfReprap) || FLAVOR_IS(gcfRepetier)) && long_retract)
+            else if ((FLAVOR_IS(gcfRepRap) || FLAVOR_IS(gcfRepetier)) && long_retract)
                 gcode << "G10 S1";
             else
                 gcode << "G10";

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -60,7 +60,7 @@ private:
     Pointf3 _pos;
     
     std::string _travel_to_z(double z, const std::string &comment);
-    std::string _retract(double length, double restart_extra, const std::string &comment);
+    std::string _retract(double length, double restart_extra, const std::string &comment, bool long_retract);
 };
 
 } /* namespace Slic3r */

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -60,7 +60,7 @@ private:
     Pointf3 _pos;
     
     std::string _travel_to_z(double z, const std::string &comment);
-    std::string _retract(double length, double restart_extra, const std::string &comment, bool long_retract);
+    std::string _retract(double length, double restart_extra, const std::string &comment, bool long_retract = false);
 };
 
 } /* namespace Slic3r */

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -24,7 +24,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    is $output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw marlin retract';
+    is $output[0], "G10 S1 ; retract for toolchange extruder 0", 'Produces long retract for fw marlin retract';
 }
 
 {
@@ -38,7 +38,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    is $output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw repetier retract';
+    is $output[0], "G10 S1 ; retract for toolchange extruder 0", 'Produces long retract for fw repetier retract';
 
 }
 {
@@ -53,7 +53,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    ok($output[0] eq "G10 ; retract for toolchange", 'Produces regular retract for flavors that are not Marlin or Repetier');
+    ok($output[0] eq "G10 ; retract for toolchange extruder 0", 'Produces regular retract for flavors that are not Marlin or Repetier');
 
 }
 

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Slic3r::XS;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 {
     my $gcodegen = Slic3r::GCode->new;
@@ -14,4 +14,44 @@ use Test::More tests => 2;
     is_deeply $gcodegen->origin->pp, [15,5], 'origin returns reference to point';
 }
 
+{
+    my $config = Slic3r::Config->new_from_defaults;
+    $config->set('use_firmware_retraction', 1)
+    $config->set('gcode_flavor', 'reprap')
+
+    my $gcodegen = Slic3r::GCode->new;
+    my $output = $gcodegen->writer->retract_for_toolchange;
+    is $output, "G10 S1; retract for toolchange"
+{
+    my $config = Slic3r::Config->new_from_defaults;
+    $config->set('use_firmware_retraction', 1)
+    $config->set('gcode_flavor', 'reprap')
+
+    my $gcodegen = Slic3r::GCode->new;
+    my $output = $gcodegen->writer->retract_for_toolchange;
+    is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw marlin retract';
+}
+
+{
+    my $config = Slic3r::Config->new_from_defaults;
+    $config->set('use_firmware_retraction', 1)
+    $config->set('gcode_flavor', 'repetier')
+
+    my $gcodegen = Slic3r::GCode->new;
+    my $output = $gcodegen->writer->retract_for_toolchange;
+    is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw repetier retract';
+
+}
+{
+    my $config = Slic3r::Config->new_from_defaults;
+    $config->set('gcode_flavor', 'smoothie')
+    $config->set('use_firmware_retraction', 1)
+
+    my $gcodegen = Slic3r::GCode->new;
+    my $output = $gcodegen->writer->retract_for_toolchange;
+    is $output, "G10; retract for toolchange", 'Produces regular retract for non-reprap';
+
+}
+
+}
 __END__

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -24,7 +24,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    is @output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw marlin retract';
+    is $output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw marlin retract';
 }
 
 {
@@ -38,7 +38,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    is @output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw repetier retract';
+    is $output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw repetier retract';
 
 }
 {
@@ -53,7 +53,7 @@ use Test::More tests => 5;
     $gcodegen->writer->set_extruders([0]);
     $gcodegen->writer->set_extruder(0);
     my @output = split(/\n/, $gcodegen->retract(1));
-    ok(@output[0] eq "G10 ; retract for toolchange", 'Produces regular retract for flavors that are not Marlin or Repetier');
+    ok($output[0] eq "G10 ; retract for toolchange", 'Produces regular retract for flavors that are not Marlin or Repetier');
 
 }
 

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -15,33 +15,37 @@ use Test::More tests => 5;
 }
 
 {
-    my $config = Slic3r::Config->new_from_defaults;
-    $config->set('use_firmware_retraction', 1)
-    $config->set('gcode_flavor', 'reprap')
-
+    my $config = Slic3r::Config::Static::new_FullPrintConfig;
     my $gcodegen = Slic3r::GCode->new;
-    my $output = $gcodegen->writer->retract_for_toolchange;
+    $config->set('use_firmware_retraction', 1);
+    $config->set('gcode_flavor', "reprap");
+    $gcodegen->apply_print_config($config);
+    printf($gcodegen->retract . " <- \n");
+    my $output = $gcodegen->retract(1);
     is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw marlin retract';
 }
 
 {
-    my $config = Slic3r::Config->new_from_defaults;
-    $config->set('use_firmware_retraction', 1)
-    $config->set('gcode_flavor', 'repetier')
+    my $config = Slic3r::Config::Static::new_FullPrintConfig;
+    $config->set('use_firmware_retraction', 1);
+    $config->set('gcode_flavor', "repetier");
 
     my $gcodegen = Slic3r::GCode->new;
-    my $output = $gcodegen->writer->retract_for_toolchange;
+    $gcodegen->apply_print_config($config);
+    my $output = $gcodegen->retract(1);
     is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw repetier retract';
 
 }
 {
-    my $config = Slic3r::Config->new_from_defaults;
-    $config->set('gcode_flavor', 'smoothie')
-    $config->set('use_firmware_retraction', 1)
+    my $config = Slic3r::Config::Static::new_FullPrintConfig;
+    $config->set('gcode_flavor', "smoothie");
+    $config->set('use_firmware_retraction', 1);
 
     my $gcodegen = Slic3r::GCode->new;
-    my $output = $gcodegen->writer->retract_for_toolchange;
-    is $output, "G10; retract for toolchange", 'Produces regular retract for non-reprap';
+    $gcodegen->apply_print_config($config);
+
+    my $output = $gcodegen->retract(1);
+    ok($output eq "G10; retract for toolchange", 'Produces regular retract for non-reprap');
 
 }
 

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -19,33 +19,41 @@ use Test::More tests => 5;
     my $gcodegen = Slic3r::GCode->new;
     $config->set('use_firmware_retraction', 1);
     $config->set('gcode_flavor', "reprap");
+    $config->set('gcode_comments', 1);
     $gcodegen->apply_print_config($config);
-    printf($gcodegen->retract . " <- \n");
-    my $output = $gcodegen->retract(1);
-    is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw marlin retract';
+    $gcodegen->writer->set_extruders([0]);
+    $gcodegen->writer->set_extruder(0);
+    my @output = split(/\n/, $gcodegen->retract(1));
+    is @output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw marlin retract';
 }
 
 {
     my $config = Slic3r::Config::Static::new_FullPrintConfig;
     $config->set('use_firmware_retraction', 1);
     $config->set('gcode_flavor', "repetier");
+    $config->set('gcode_comments', 1);
 
     my $gcodegen = Slic3r::GCode->new;
     $gcodegen->apply_print_config($config);
-    my $output = $gcodegen->retract(1);
-    is $output, "G10 S1; retract for toolchange", 'Produces long retract for fw repetier retract';
+    $gcodegen->writer->set_extruders([0]);
+    $gcodegen->writer->set_extruder(0);
+    my @output = split(/\n/, $gcodegen->retract(1));
+    is @output[0], "G10 S1 ; retract for toolchange", 'Produces long retract for fw repetier retract';
 
 }
 {
     my $config = Slic3r::Config::Static::new_FullPrintConfig;
     $config->set('gcode_flavor', "smoothie");
     $config->set('use_firmware_retraction', 1);
+    $config->set('gcode_comments', 1);
 
     my $gcodegen = Slic3r::GCode->new;
     $gcodegen->apply_print_config($config);
 
-    my $output = $gcodegen->retract(1);
-    ok($output eq "G10; retract for toolchange", 'Produces regular retract for non-reprap');
+    $gcodegen->writer->set_extruders([0]);
+    $gcodegen->writer->set_extruder(0);
+    my @output = split(/\n/, $gcodegen->retract(1));
+    ok(@output[0] eq "G10 ; retract for toolchange", 'Produces regular retract for flavors that are not Marlin or Repetier');
 
 }
 

--- a/xs/t/21_gcode.t
+++ b/xs/t/21_gcode.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Slic3r::XS;
-use Test::More tests => 3;
+use Test::More tests => 5;
 
 {
     my $gcodegen = Slic3r::GCode->new;
@@ -14,14 +14,6 @@ use Test::More tests => 3;
     is_deeply $gcodegen->origin->pp, [15,5], 'origin returns reference to point';
 }
 
-{
-    my $config = Slic3r::Config->new_from_defaults;
-    $config->set('use_firmware_retraction', 1)
-    $config->set('gcode_flavor', 'reprap')
-
-    my $gcodegen = Slic3r::GCode->new;
-    my $output = $gcodegen->writer->retract_for_toolchange;
-    is $output, "G10 S1; retract for toolchange"
 {
     my $config = Slic3r::Config->new_from_defaults;
     $config->set('use_firmware_retraction', 1)
@@ -53,5 +45,4 @@ use Test::More tests => 3;
 
 }
 
-}
 __END__


### PR DESCRIPTION
This is in the spec for both repetier and marlinfw.

Implements #4106 

Test checks for output from gcode->retract(). 