### PR TITLE
Update required ParseXS and XSpp versions

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,7 +12,7 @@ my %prereqs = qw(
     Encode::Locale                  1.05
     ExtUtils::CppGuess              0
     ExtUtils::MakeMaker             6.80
-    ExtUtils::ParseXS               3.22
+    ExtUtils::ParseXS               3.35
     File::Basename                  0
     File::Spec                      0
     Getopt::Long                    0

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -222,10 +222,10 @@ my $build = Module::Build::WithXSpp->new(
     module_name     => 'Slic3r::XS',
     dist_abstract   => 'XS code for Slic3r',
     build_requires => {qw(
-        ExtUtils::ParseXS           3.18
+        ExtUtils::ParseXS           3.35
         ExtUtils::Typemaps          1.00
         ExtUtils::Typemaps::Default 1.05
-        ExtUtils::XSpp              0.17
+        ExtUtils::XSpp              0.18
         Module::Build               0.3601
         Test::More                  0
     )},


### PR DESCRIPTION
While trying to build Slic3r for NixOS I noticed that it fails for older versions of ExtUtil::ParseXS and ExtUtil::XSpp.  I would recommend to update the required versions.  These versions are the ones that recent Travis CI build seem to be using