### PR TITLE
Fix for issue #4021 - Crash due to backslash at end of text fields for Custom G-code

### DIFF
--- a/xs/src/libslic3r/Config.cpp
+++ b/xs/src/libslic3r/Config.cpp
@@ -32,6 +32,9 @@ std::string escape_string_cstyle(const std::string &str)
         if (c == '\n' || c == '\r') {
             (*outptr ++) = '\\';
             (*outptr ++) = 'n';
+	} if (c == '\\'){
+	    (*outptr ++) = '\\';
+	    (*outptr ++) = '\\';
         } else
             (*outptr ++) = c;
     }

--- a/xs/src/libslic3r/Config.cpp
+++ b/xs/src/libslic3r/Config.cpp
@@ -32,9 +32,9 @@ std::string escape_string_cstyle(const std::string &str)
         if (c == '\n' || c == '\r') {
             (*outptr ++) = '\\';
             (*outptr ++) = 'n';
-	} if (c == '\\'){
-	    (*outptr ++) = '\\';
-	    (*outptr ++) = '\\';
+        } else if (c == '\\'){
+            (*outptr ++) = '\\';
+            (*outptr ++) = '\\';
         } else
             (*outptr ++) = c;
     }


### PR DESCRIPTION
**Problem:**

Backslashes were not escaped during serialization by *escape_string_cstyle()*. If the backslash is located at the end of the string the next call to *unescape_string_cstyle()* detects a backslash without another character following and returns false. This terminates slic3r.

**Solution:**

Backslashes are now escaped and *unescape_string_cstyle()* will not fail anymore.