### PR TITLE
Fix generating supports for very thin hovering slices

### DIFF
--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -179,8 +179,8 @@ sub contact_area {
                     }
                 
                     $diff = diff(
-                        offset([ map $_->p, @{$layerm->slices} ], -$d),
-                        [ map @$_, @{$lower_layer->slices} ],
+                        [ map $_->p, @{$layerm->slices} ],
+                        offset([ map @$_, @{$lower_layer->slices} ], +$d),
                     );
                 
                     # only enforce spacing from the object ($fw/2) if the threshold angle


### PR DESCRIPTION
fix for #4054

Currently, slic3r does not generate support for very thin hovering surfaces. This PR fixes the issue. See the [link](https://www.dropbox.com/s/mecr68mqw035wrb/Grand%20Snaget-Jofo%20%281%29.stl?dl=0) for an example model.

