### PR TITLE
Fixes tab/space artefact from adaptive-slicing merge

### DIFF
--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -154,8 +154,8 @@ class StaticPrintConfig : public PrintConfigBase, public StaticConfig
 class PrintObjectConfig : public virtual StaticPrintConfig
 {
     public:
-	ConfigOptionBool                adaptive_slicing;
-	ConfigOptionPercent             adaptive_slicing_quality;
+    ConfigOptionBool                adaptive_slicing;
+    ConfigOptionPercent             adaptive_slicing_quality;
     ConfigOptionBool                dont_support_bridges;
     ConfigOptionFloatOrPercent      extrusion_width;
     ConfigOptionFloatOrPercent      first_layer_height;


### PR DESCRIPTION
Just replaced tabs with spaces in two lines for cleaner code. No side effects. 