### PR TITLE
Fix comparison bw integer and pointer

### DIFF
--- a/xs/src/boost/nowide/cenv.hpp
+++ b/xs/src/boost/nowide/cenv.hpp
@@ -101,7 +101,7 @@ namespace nowide {
     {
         char const *key = string;
         char const *key_end = string;
-        while(*key_end!='=' && key_end!='\0')
+        while(*key_end!='=' && *key_end!='\0')
             key_end++;
         if(*key_end == '\0')
             return -1;

--- a/xs/src/boost/nowide/cenv.hpp
+++ b/xs/src/boost/nowide/cenv.hpp
@@ -99,8 +99,10 @@ namespace nowide {
     ///
     inline int putenv(char *string)
     {
+        if (string == nullptr) return -1;
         char const *key = string;
         char const *key_end = string;
+        
         while(*key_end!='=' && *key_end!='\0')
             key_end++;
         if(*key_end == '\0')


### PR DESCRIPTION
This error is encountered while compiling on `gcc version 7.1.0 (x86_64-posix-seh, Built by strawberryperl.com project)`

`ISO C++ forbids comparison between pointer and integer [-fpermissive]`

This PR fixes the error.

Issue on original repository: https://github.com/artyom-beilis/nowide/issues/22