### PR TITLE
Add pause-at-layer functionality for 3092

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -441,7 +441,7 @@ sub options {
         perimeters spiral_vase
         top_solid_layers bottom_solid_layers
         extra_perimeters avoid_crossing_perimeters thin_walls overhangs
-        seam_position external_perimeters_first
+        seam_position external_perimeters_first pause_heights
         fill_density fill_pattern top_infill_pattern bottom_infill_pattern fill_gaps
         infill_every_layers infill_only_where_needed
         solid_infill_every_layers fill_angle solid_infill_below_area 
@@ -543,6 +543,7 @@ sub build {
             my $optgroup = $page->new_optgroup('Advanced');
             $optgroup->append_single_option_line('seam_position');
             $optgroup->append_single_option_line('external_perimeters_first');
+            $optgroup->append_single_option_line('pause_heights');
         }
     }
     
@@ -1211,7 +1212,7 @@ sub options {
         host_type print_host octoprint_apikey
         use_firmware_retraction pressure_advance vibration_limit
         use_volumetric_e
-        start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode between_objects_gcode
+        start_gcode end_gcode before_layer_gcode layer_gcode pause_gcode toolchange_gcode between_objects_gcode
         nozzle_diameter extruder_offset min_layer_height max_layer_height
         retract_length retract_lift retract_speed retract_restart_extra retract_before_travel retract_layer_change wipe
         retract_length_toolchange retract_restart_extra_toolchange retract_lift_above retract_lift_below
@@ -1401,6 +1402,15 @@ sub build {
                 label_width => 0,
             );
             my $option = $optgroup->get_option('layer_gcode');
+            $option->full_width(1);
+            $option->height(150);
+            $optgroup->append_single_option_line($option);
+        }
+        {
+            my $optgroup = $page->new_optgroup('Pause G-code',
+                label_width => 0,
+            );
+            my $option = $optgroup->get_option('pause_gcode');
             $option->full_width(1);
             $option->height(150);
             $optgroup->append_single_option_line($option);

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -453,6 +453,16 @@ sub process_layer {
         $pp->set('layer_z'   => $layer->print_z);
         $gcode .= Slic3r::ConditionalGCode::apply_math($pp->process($self->print->config->layer_gcode) . "\n");
     }
+    if ($self->print->config->pause_gcode && $self->print->config->pause_heights) {
+        foreach my $height (split / /, $self->print->config->pause_heights) {
+            if ($height && $height eq $layer->print_z) {
+                my $pp = $self->_gcodegen->placeholder_parser->clone;
+                $pp->set('layer_num' => $self->_gcodegen->layer_index);
+                $pp->set('layer_z'   => $layer->print_z);
+                $gcode .= Slic3r::ConditionalGCode::apply_math($pp->process($self->print->config->pause_gcode) . "\n");
+            }
+        }
+    }
     
     # extrude skirt along raft layers and normal object layers
     # (not along interlaced support material layers)

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -85,6 +85,22 @@ PrintConfigDef::PrintConfigDef()
     def->height = 50;
     def->default_value = new ConfigOptionString("");
 
+    def = this->add("pause_gcode", coString);
+    def->label = "Pause G-code";
+    def->tooltip = "This custom code is inserted at every layer change corresponding to the \"Pause Heights\" setting. It is inserted right after retraction and Z-Hop. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->cli = "pause-gcode=s";
+    def->multiline = true;
+    def->full_width = true;
+    def->height = 50;
+    def->default_value = new ConfigOptionString("");
+
+    def = this->add("pause_heights", coString);
+    def->label = "Pause Heights";
+    def->category = "Layers and Perimeters";
+    def->tooltip = "A list of heights separated by spaces. When generating G-code, your \"Pause G-code\" will be inserted at these heights.";
+    def->cli = "pause_heights=s";
+    def->default_value = new ConfigOptionString("");
+
     def = this->add("between_objects_gcode", coString);
     def->label = "Between objects G-code";
     def->tooltip = "This code is inserted between objects when using sequential printing. By default extruder and bed temperature are reset using non-wait command; however if M104, M109, M140 or M190 are detected in this custom code, Slic3r will not add temperature commands. Note that you can use placeholder variables for all Slic3r settings, so you can put a \"M109 S[first_layer_temperature]\" command wherever you want.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -314,6 +314,8 @@ class PrintRegionConfig : public virtual StaticPrintConfig
 class GCodeConfig : public virtual StaticPrintConfig
 {
     public:
+    ConfigOptionString              pause_gcode;
+    ConfigOptionString              pause_heights;
     ConfigOptionString              before_layer_gcode;
     ConfigOptionString              between_objects_gcode;
     ConfigOptionString              end_gcode;
@@ -355,6 +357,8 @@ class GCodeConfig : public virtual StaticPrintConfig
     }
     
     virtual ConfigOption* optptr(const t_config_option_key &opt_key, bool create = false) {
+        OPT_PTR(pause_gcode);
+        OPT_PTR(pause_heights);
         OPT_PTR(before_layer_gcode);
         OPT_PTR(between_objects_gcode);
         OPT_PTR(end_gcode);


### PR DESCRIPTION
Added 2 new configuration parameters: pause_gcode and pause_heights.

pause_gcode is under the Custom G-Code section of Printer Configuration.
pause_heights is under Layers and perimeters section of Print Configuration.

also added a test case.