### PR TITLE
Auto align z preference

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -84,6 +84,7 @@ our $Settings = {
     _ => {
         version_check => 1,
         autocenter => 1,
+        autoalignz => 1,
         invert_zoom => 0,
         background_processing => 0,
         threads => $Slic3r::Config::Options->{threads}{default},

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1265,12 +1265,16 @@ sub load_model_objects {
                 # if user turned autocentering off, automatic arranging would disappoint them
                 $need_arrange = 0;
 
-                $o->align_to_ground; # aligns object to Z = 0
+                if ($Slic3r::GUI::Settings->{_}{autoalignz}) {
+                    $o->align_to_ground; # aligns object to Z = 0
+                }
                 $o->add_instance();
             }
         } else {
-            # if object has defined positions we still need to ensure it's aligned to Z = 0
-            $o->align_to_ground;
+            if ($Slic3r::GUI::Settings->{_}{autoalignz}) {
+                # if object has defined positions we still need to ensure it's aligned to Z = 0
+                $o->align_to_ground;
+            }
         }
         
         {

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -43,6 +43,13 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{autocenter},
     ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+        opt_id      => 'autoalignz',
+        type        => 'bool',
+        label       => 'Auto-align parts (z=0)',
+        tooltip     => 'If this is enabled, Slic3r will auto-align objects z value to be on the print bed at z=0.',
+        default     => $Slic3r::GUI::Settings->{_}{autoalignz},
+    ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'invert_zoom',
         type        => 'bool',
         label       => 'Invert zoom in previews',

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -38,7 +38,7 @@ sub new {
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'autocenter',
         type        => 'bool',
-        label       => 'Auto-center parts',
+        label       => 'Auto-center parts (x,y)',
         tooltip     => 'If this is enabled, Slic3r will auto-center objects around the print bed center.',
         default     => $Slic3r::GUI::Settings->{_}{autocenter},
     ));


### PR DESCRIPTION
This adds a new preference to turn off auto alignment on the z axis (z=0). This can be useful when the input file already contains the correct z-axis location, as discussed here: https://github.com/alexrj/Slic3r/issues/404#issuecomment-349438749