### PR TITLE
apply conditional gcode parser to tool change gcode

### DIFF
--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -448,6 +448,7 @@ sub process_layer {
         my $pp = $self->_gcodegen->placeholder_parser->clone;
         $pp->set('layer_num' => $self->_gcodegen->layer_index + 1);
         $pp->set('layer_z'   => $layer->print_z);
+        $pp->set('current_retraction' => $self->_gcodegen->writer->extruder->retracted);
         $gcode .= Slic3r::ConditionalGCode::apply_math($pp->process($self->print->config->before_layer_gcode) . "\n");
     }
     $gcode .= $self->_gcodegen->change_layer($layer->as_layer);  # this will increase $self->_gcodegen->layer_index
@@ -455,6 +456,7 @@ sub process_layer {
         my $pp = $self->_gcodegen->placeholder_parser->clone;
         $pp->set('layer_num' => $self->_gcodegen->layer_index);
         $pp->set('layer_z'   => $layer->print_z);
+        $pp->set('current_retraction' => $self->_gcodegen->writer->extruder->retracted);
         $gcode .= Slic3r::ConditionalGCode::apply_math($pp->process($self->print->config->layer_gcode) . "\n");
     }
     

--- a/xs/src/libslic3r/ConditionalGcode.hpp
+++ b/xs/src/libslic3r/ConditionalGcode.hpp
@@ -3,6 +3,9 @@
  * 
  */
 
+#ifndef slic3r_ConditionalGcode_hpp_
+#define slic3r_ConditionalGcode_hpp_
+
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -31,3 +34,5 @@ std::string expression(const std::string& input, const int depth = 0);
 std::string apply_math(const std::string& input);
 
 }
+
+#endif

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -755,6 +755,8 @@ GCode::set_extruder(unsigned int extruder_id)
         PlaceholderParser pp = *this->placeholder_parser;
         pp.set("previous_extruder", this->writer.extruder()->id);
         pp.set("next_extruder",     extruder_id);
+        pp.set("previous_retraction", this->writer.extruder()->retracted);
+        pp.set("next_retraction", this->writer.extruders.find(extruder_id)->second.retracted);
         gcode += Slic3r::apply_math(pp.process(this->config.toolchange_gcode.value))  + '\n';
     }
     

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -755,7 +755,7 @@ GCode::set_extruder(unsigned int extruder_id)
         PlaceholderParser pp = *this->placeholder_parser;
         pp.set("previous_extruder", this->writer.extruder()->id);
         pp.set("next_extruder",     extruder_id);
-        gcode += pp.process(this->config.toolchange_gcode.value) + '\n';
+        gcode += Slic3r::apply_math(pp.process(this->config.toolchange_gcode.value))  + '\n';
     }
     
     // if ooze prevention is enabled, park current extruder in the nearest

--- a/xs/src/libslic3r/GCode.hpp
+++ b/xs/src/libslic3r/GCode.hpp
@@ -10,6 +10,7 @@
 #include "PlaceholderParser.hpp"
 #include "Print.hpp"
 #include "PrintConfig.hpp"
+#include "ConditionalGcode.hpp"
 #include <string>
 
 namespace Slic3r {

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -78,7 +78,7 @@ PrintConfigDef::PrintConfigDef()
 
     def = this->add("before_layer_gcode", coString);
     def->label = "Before layer change G-code";
-    def->tooltip = "This custom code is inserted at every layer change, right before the Z move. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->tooltip = "This custom code is inserted at every layer change, right before the Z move. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num], [layer_z] and [current_retraction].";
     def->cli = "before-layer-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -755,7 +755,7 @@ PrintConfigDef::PrintConfigDef()
 
     def = this->add("layer_gcode", coString);
     def->label = "After layer change G-code";
-    def->tooltip = "This custom code is inserted at every layer change, right after the Z move and before the extruder moves to the first layer point. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->tooltip = "This custom code is inserted at every layer change, right after the Z move and before the extruder moves to the first layer point. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num], [layer_z] and [current_retraction].";
     def->cli = "after-layer-gcode|layer-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -1556,7 +1556,7 @@ PrintConfigDef::PrintConfigDef()
     
     def = this->add("toolchange_gcode", coString);
     def->label = "Tool change G-code";
-    def->tooltip = "This custom code is inserted right before every extruder change. Note that you can use placeholder variables for all Slic3r settings as well as [previous_extruder] and [next_extruder].";
+    def->tooltip = "This custom code is inserted right before every extruder change. Note that you can use placeholder variables for all Slic3r settings as well as [previous_extruder], [next_extruder], [previous_retraction] and [next_retraction].";
     def->cli = "toolchange-gcode=s";
     def->multiline = true;
     def->full_width = true;


### PR DESCRIPTION
In the current version, the conditional gcode parser doesn't apply to tool change G-codes, which is a major drawback (at least in my use-cases).
This PR executes the conditional parser for every toolchange.
I had to add an include guard to `ConditionalGcode.hpp` since it is already included via XS, otherwise it is a one-liner.