### PR TITLE
show close button for the first profile editor tab if controller tab is disabled

### DIFF
--- a/lib/Slic3r/GUI/MainFrame.pm
+++ b/lib/Slic3r/GUI/MainFrame.pm
@@ -100,6 +100,8 @@ sub _init_tabpanel {
         $panel->OnActivate if $panel->can('OnActivate');
         if ($self->{tabpanel}->GetSelection > 1) {
             $self->{tabpanel}->SetWindowStyle($self->{tabpanel}->GetWindowStyleFlag | wxAUI_NB_CLOSE_ON_ACTIVE_TAB);
+        } elsif(($Slic3r::GUI::Settings->{_}{show_host} == 0) && ($self->{tabpanel}->GetSelection == 1)){
+            $self->{tabpanel}->SetWindowStyle($self->{tabpanel}->GetWindowStyleFlag | wxAUI_NB_CLOSE_ON_ACTIVE_TAB);
         } else {
             $self->{tabpanel}->SetWindowStyle($self->{tabpanel}->GetWindowStyleFlag & ~wxAUI_NB_CLOSE_ON_ACTIVE_TAB);
         }


### PR DESCRIPTION
This fixes the following issue:

The close button for the first profile editor tab is not shown if "Display profile editors as tabs" is enabled and "Show Controller Tab" is disabled (in File -> Preferences...).