### PR TITLE
Solarized Color Scheme

### DIFF
--- a/lib/Slic3r/GUI/2DBed.pm
+++ b/lib/Slic3r/GUI/2DBed.pm
@@ -18,9 +18,12 @@ __PACKAGE__->mk_accessors(qw(bed_shape interactive pos _scale_factor _shift on_m
 
 sub new {
     my ($class, $parent, $bed_shape) = @_;
-
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    
+    if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
+        my $myGetSchemeName = \&{"Slic3r::GUI::ColorScheme::$Slic3r::GUI::Settings->{_}{colorscheme}"};
+        $myGetSchemeName->();
+    } else {
+        Slic3r::GUI::ColorScheme->getDefault();
     }
     
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, [250,-1], wxTAB_TRAVERSAL);
@@ -45,9 +48,10 @@ sub _repaint {
         # On MacOS the background is erased, on Windows the background is not erased 
         # and on Linux/GTK the background is erased to gray color.
         # Fill DC with the background on Windows & Linux/GTK.
-        my $color = Wx::SystemSettings::GetSystemColour(wxSYS_COLOUR_3DLIGHT);
-        $dc->SetPen(Wx::Pen->new($color, 1, wxSOLID));
-        $dc->SetBrush(Wx::Brush->new($color, wxSOLID));
+        my $brush_background = Wx::Brush->new(Wx::Colour->new(@BACKGROUND255), wxSOLID);
+        my $pen_background   = Wx::Pen->new(Wx::Colour->new(@BACKGROUND255), 1, wxSOLID);
+        $dc->SetPen($pen_background);
+        $dc->SetBrush($brush_background);
         my $rect = $self->GetUpdateRegion()->GetBox();
         $dc->DrawRectangle($rect->GetLeft(), $rect->GetTop(), $rect->GetWidth(), $rect->GetHeight());
     }

--- a/lib/Slic3r/GUI/2DBed.pm
+++ b/lib/Slic3r/GUI/2DBed.pm
@@ -11,10 +11,17 @@ use Wx qw(:misc :pen :brush :font :systemsettings wxTAB_TRAVERSAL wxSOLID);
 use Wx::Event qw(EVT_PAINT EVT_ERASE_BACKGROUND EVT_MOUSE_EVENTS EVT_SIZE);
 use base qw(Wx::Panel Class::Accessor);
 
+# Color Scheme
+use Slic3r::GUI::ColorScheme;
+
 __PACKAGE__->mk_accessors(qw(bed_shape interactive pos _scale_factor _shift on_move _painted));
 
 sub new {
     my ($class, $parent, $bed_shape) = @_;
+
+    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
+        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    }
     
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, [250,-1], wxTAB_TRAVERSAL);
     $self->{user_drawn_background} = $^O ne 'darwin';
@@ -89,7 +96,7 @@ sub _repaint {
     # draw bed fill
     {
         $dc->SetPen(Wx::Pen->new(Wx::Colour->new(0,0,0), 1, wxSOLID));
-        $dc->SetBrush(Wx::Brush->new(Wx::Colour->new(255,255,255), wxSOLID));
+        $dc->SetBrush(Wx::Brush->new(Wx::Colour->new(@BED_COLOR), wxSOLID));
         $dc->DrawPolygon([ map $self->to_pixels($_), @$bed_shape ], 0, 0);
     }
     
@@ -105,7 +112,7 @@ sub _repaint {
         }
         @polylines = @{intersection_pl(\@polylines, [$bed_polygon])};
         
-        $dc->SetPen(Wx::Pen->new(Wx::Colour->new(230,230,230), 1, wxSOLID));
+        $dc->SetPen(Wx::Pen->new(Wx::Colour->new(@BED_GRID), 1, wxSOLID));
         $dc->DrawLine(map @{$self->to_pixels([map unscale($_), @$_])}, @$_[0,-1]) for @polylines;
     }
     

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -788,7 +788,12 @@ sub Render {
     $self->SetCurrent($context);
     $self->InitGL;
     
-    glClearColor(1, 1, 1, 1);
+    if($SOLID_BACKGROUNDCOLOR == 1){
+        glClearColor(@BACKGROUND_COLOR, 0);
+    } else {
+        glClearColor(1, 1, 1, 1);
+    }
+    
     glClearDepth(1);
     glDepthFunc(GL_LESS);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -841,7 +846,7 @@ sub Render {
     }
     
     # draw fixed background
-    if ($self->background) {
+    if ($SOLID_BACKGROUNDCOLOR == 0 && $self->background) {
         glDisable(GL_LIGHTING);
         glPushMatrix();
         glLoadIdentity();
@@ -851,11 +856,10 @@ sub Render {
         glLoadIdentity();
         
         glBegin(GL_QUADS);
-        
-        glColor3f( @TOP_COLOR ); # top color
+        glColor3f( @BOTTOM_COLOR ); # bottom color
         glVertex2f(-1.0,-1.0);
         glVertex2f(1,-1.0);
-        glColor3f( @BOTTOM_COLOR ); # bottom color
+        glColor3f( @TOP_COLOR ); # top color
         glVertex2f(1, 1);
         glVertex2f(-1.0, 1);
         glEnd();

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -1184,6 +1184,7 @@ sub default_colors { [@COLOR_PARTS], [@COLOR_INFILL], [@COLOR_SUPPORT], [@COLOR_
 
 sub new {
     my $class = shift;
+    
     my $self = $class->SUPER::new(@_);
     # Get SOLARIZED if enabled
     if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -51,10 +51,10 @@ our $BOTTOM_COLOR;    # Background BOTTOM color
 our $TOP_COLOR;       # Background TOP color
 our $GRID_COLOR;
 our $GROUND_COLOR;    # PLATE color
-our $COLOR_ONE;       # PARTS
-our $COLOR_TWO;       # INFILL
-our $COLOR_THREE;     # ?
-our $COLOR_FOUR;      # ?
+our $COLOR_PARTS;     # PARTS
+our $COLOR_INFILL;    # INFILL
+our $COLOR_SUPPORT;   # Support
+our $COLOR_FOUR;      # ? what is this color for ?
 our $COLOR_CUTPLANE;
 
 # S O L A R I Z E
@@ -103,13 +103,17 @@ sub getColorScheme {
     # get/set color theme
     if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
         #print "Using S O L A R I Z E color scheme\n";
-        $SELECTED_COLOR = $COLOR_MAGENTA;
-        $HOVER_COLOR    = $COLOR_VIOLET;
-        $TOP_COLOR      = $COLOR_BASE2;
-        $BOTTOM_COLOR   = $COLOR_BASE2;
-        $GRID_COLOR     = [@{$COLOR_BASE02},0.4];#[0.02745,0.21176,0.25882, 0.4]; # COLOR_BASE02
-        $GROUND_COLOR   = [@{$COLOR_BASE2},0.4];#0.93333,0.90980,0.83529, 0.4]; # COLOR_BASE2
+        $SELECTED_COLOR = $COLOR_MAGENTA;         # Selected Model
+        $HOVER_COLOR    = $COLOR_VIOLET;          # Hover over Model
+        $TOP_COLOR      = $COLOR_BASE3;           # Backgroud color
+        $BOTTOM_COLOR   = $COLOR_BASE3;           # Backgroud color
+        $GRID_COLOR     = [@{$COLOR_BASE02},0.4]; # Grid color
+        $GROUND_COLOR   = [@{$COLOR_BASE2},0.4];  # Ground or Plate color
         $COLOR_CUTPLANE = [@{$COLOR_BASE1},0.5];
+        $COLOR_PARTS    = [@{$COLOR_BLUE},1];     # Perimeter color
+        $COLOR_INFILL   = [@{$COLOR_BASE2},1];
+        $COLOR_SUPPORT  = [@{$COLOR_ORANGE},1];
+        $COLOR_FOUR     = [@{$COLOR_CYAN},1];
     } else {
         $SELECTED_COLOR = [0,1,0];
         $HOVER_COLOR    = [0.4,0.9,0];
@@ -118,13 +122,16 @@ sub getColorScheme {
         $GRID_COLOR     = [0.2, 0.2, 0.2, 0.4];
         $GROUND_COLOR   = [0.8, 0.6, 0.5, 0.4];
         $COLOR_CUTPLANE = [.8, .8, .8, 0.5];
+        $COLOR_PARTS    = [1,0.95,0.2,1];
+        $COLOR_INFILL   = [1,0.45,0.45,1];
+        $COLOR_SUPPORT  = [0.5,1,0.5,1];
+        $COLOR_FOUR     = [0.5,0.5,1,1];
     }
 }
 
 sub new {
     my ($class, $parent) = @_;
     getColorScheme();
-
     # We can only enable multi sample anti aliasing with wxWidgets 3.0.3 and with a hacked Wx::GLCanvas,
     # which exports some new WX_GL_XXX constants, namely WX_GL_SAMPLE_BUFFERS and WX_GL_SAMPLES.
     my $can_multisample =
@@ -1228,26 +1235,12 @@ __PACKAGE__->mk_accessors(qw(
     _objects_by_volumes
 ));
 
-sub getDefaultColors{
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        #print "SOLARIZE";
-        $COLOR_ONE    = [@{$COLOR_BLUE},1];
-        $COLOR_TWO    = [@{$COLOR_YELLOW},1];
-        $COLOR_THREE  = [@{$COLOR_VIOLET},1];
-        $COLOR_FOUR   = [@{$COLOR_CYAN},1];
-    } else {
-        $COLOR_ONE    = [1,0.95,0.2,1];
-        $COLOR_TWO    = [1,0.45,0.45,1];
-        $COLOR_THREE  = [0.5,1,0.5,1];
-        $COLOR_FOUR   = [0.5,0.5,1,1];
-    }
-}
-sub default_colors { $COLOR_ONE, $COLOR_TWO, $COLOR_THREE, $COLOR_FOUR }
+
+sub default_colors { $COLOR_PARTS, $COLOR_INFILL, $COLOR_SUPPORT, $COLOR_FOUR }
 
 
 sub new {
     my $class = shift;
-    getDefaultColors();
     my $self = $class->SUPER::new(@_);
     $self->colors([ $self->default_colors ]);
     $self->color_by('volume');      # object | volume

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -754,7 +754,7 @@ sub InitGL {
     glEnable(GL_MULTISAMPLE) if ($self->{can_multisample});
     
     # ambient lighting
-    glLightModelfv_p(GL_LIGHT_MODEL_AMBIENT, 0.3, 0.3, 0.3, 1);
+    glLightModelfv_p(GL_LIGHT_MODEL_AMBIENT, 0.1, 0.1, 0.1, 1);
     
     glEnable(GL_LIGHTING);
     glEnable(GL_LIGHT0);
@@ -762,10 +762,10 @@ sub InitGL {
     
     # light from camera
     glLightfv_p(GL_LIGHT1, GL_POSITION, 1, 0, 1, 0);
-    glLightfv_p(GL_LIGHT1, GL_SPECULAR, 0.3, 0.3, 0.3, 1);
-    glLightfv_p(GL_LIGHT1, GL_DIFFUSE,  0.2, 0.2, 0.2, 1);
+    glLightfv_p(GL_LIGHT1, GL_SPECULAR, 0.8, 0.8, 0.8, 1);
+    glLightfv_p(GL_LIGHT1, GL_DIFFUSE,  0.4, 0.4, 0.4, 1);
     
-    # Enables Smooth Color Shading; try GL_FLAT for (lack of) fun.
+    # Enables Smooth Color Shading; try GL_FLAT for (lack of) fun. Default: GL_SMOOTH
     glShadeModel(GL_SMOOTH);
     
     glMaterialfv_p(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, 0.3, 0.3, 0.3, 1);

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -44,38 +44,6 @@ __PACKAGE__->mk_accessors( qw(_quat _dirty init
 use constant TRACKBALLSIZE  => 0.8;
 use constant TURNTABLE_MODE => 1;
 use constant GROUND_Z       => -0.02;
-
-our $SELECTED_COLOR;
-our $HOVER_COLOR;
-our $BOTTOM_COLOR;    # Background BOTTOM color
-our $TOP_COLOR;       # Background TOP color
-our $GRID_COLOR;
-our $GROUND_COLOR;    # PLATE color
-our $COLOR_PARTS;     # PARTS
-our $COLOR_INFILL;    # INFILL
-our $COLOR_SUPPORT;   # Support
-our $COLOR_FOUR;      # ? what is this color for ?
-our $COLOR_CUTPLANE;
-
-# S O L A R I Z E
-# # http://ethanschoonover.com/solarized
-our $COLOR_BASE03  = [0.00000,0.16863,0.21176];
-our $COLOR_BASE02  = [0.02745,0.21176,0.25882];
-our $COLOR_BASE01  = [0.34510,0.43137,0.45882];
-our $COLOR_BASE00  = [0.39608,0.48235,0.51373];
-our $COLOR_BASE0   = [0.51373,0.58039,0.58824];
-our $COLOR_BASE1   = [0.57647,0.63137,0.63137];
-our $COLOR_BASE2   = [0.93333,0.90980,0.83529];
-our $COLOR_BASE3   = [0.99216,0.96471,0.89020];
-our $COLOR_YELLOW  = [0.70980,0.53725,0.00000];
-our $COLOR_ORANGE  = [0.79608,0.29412,0.08627];
-our $COLOR_RED     = [0.86275,0.19608,0.18431];
-our $COLOR_MAGENTA = [0.82745,0.21176,0.50980];
-our $COLOR_VIOLET  = [0.42353,0.44314,0.76863];
-our $COLOR_BLUE    = [0.14902,0.54510,0.82353];
-our $COLOR_CYAN    = [0.16471,0.63137,0.59608];
-our $COLOR_GREEN   = [0.52157,0.60000,0.00000];
-
 use constant PI             => 3.1415927;
 
 # Constant to determine if Vertex Buffer objects are used to draw
@@ -91,6 +59,9 @@ use constant VIEW_FRONT      => [0.0,90.0];
 use constant VIEW_BACK       => [180.0,90.0];
 use constant VIEW_DIAGONAL   => [45.0,45.0];
 
+# Color Scheme
+use Slic3r::GUI::ColorScheme;
+
 use constant GIMBAL_LOCK_THETA_MAX => 170;
 
 # make OpenGL::Array thread-safe
@@ -99,39 +70,12 @@ use constant GIMBAL_LOCK_THETA_MAX => 170;
     *OpenGL::Array::CLONE_SKIP = sub { 1 };
 }
 
-sub getColorScheme {
-    # get/set color theme
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        #print "Using S O L A R I Z E color scheme\n";
-        $SELECTED_COLOR = $COLOR_MAGENTA;         # Selected Model
-        $HOVER_COLOR    = $COLOR_VIOLET;          # Hover over Model
-        $TOP_COLOR      = $COLOR_BASE3;           # Backgroud color
-        $BOTTOM_COLOR   = $COLOR_BASE3;           # Backgroud color
-        $GRID_COLOR     = [@{$COLOR_BASE02},0.4]; # Grid color
-        $GROUND_COLOR   = [@{$COLOR_BASE2},0.4];  # Ground or Plate color
-        $COLOR_CUTPLANE = [@{$COLOR_BASE1},0.5];
-        $COLOR_PARTS    = [@{$COLOR_BLUE},1];     # Perimeter color
-        $COLOR_INFILL   = [@{$COLOR_BASE2},1];
-        $COLOR_SUPPORT  = [@{$COLOR_ORANGE},1];
-        $COLOR_FOUR     = [@{$COLOR_CYAN},1];
-    } else {
-        $SELECTED_COLOR = [0,1,0];
-        $HOVER_COLOR    = [0.4,0.9,0];
-        $TOP_COLOR      = [10/255,98/255,144/255];
-        $BOTTOM_COLOR   = [0,0,0];
-        $GRID_COLOR     = [0.2, 0.2, 0.2, 0.4];
-        $GROUND_COLOR   = [0.8, 0.6, 0.5, 0.4];
-        $COLOR_CUTPLANE = [.8, .8, .8, 0.5];
-        $COLOR_PARTS    = [1,0.95,0.2,1];
-        $COLOR_INFILL   = [1,0.45,0.45,1];
-        $COLOR_SUPPORT  = [0.5,1,0.5,1];
-        $COLOR_FOUR     = [0.5,0.5,1,1];
-    }
-}
-
 sub new {
     my ($class, $parent) = @_;
-    getColorScheme();
+    # Get SOLARIZED if enabled
+    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
+        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    }
     # We can only enable multi sample anti aliasing with wxWidgets 3.0.3 and with a hacked Wx::GLCanvas,
     # which exports some new WX_GL_XXX constants, namely WX_GL_SAMPLE_BUFFERS and WX_GL_SAMPLES.
     my $can_multisample =
@@ -903,10 +847,10 @@ sub Render {
         glLoadIdentity();
         
         glBegin(GL_QUADS);
-        glColor3f(@{ $BOTTOM_COLOR }); #bottom color
+        glColor3f( @BOTTOM_COLOR ); #bottom color
         glVertex2f(-1.0,-1.0);
         glVertex2f(1,-1.0);
-        glColor3f(@{ $TOP_COLOR }); #top color
+        glColor3f( @TOP_COLOR ); #top color
         glVertex2f(1, 1);
         glVertex2f(-1.0, 1);
         glEnd();
@@ -940,7 +884,7 @@ sub Render {
             # fall back on old behavior
             glVertexPointer_c(3, GL_FLOAT, 0, $self->bed_triangles->ptr());
         }
-        glColor4f( @{ $GROUND_COLOR } );
+        glColor4f( @GROUND_COLOR );
         glNormal3d(0,0,1);
         glDrawArrays(GL_TRIANGLES, 0, $self->bed_triangles->elements / 3);
         glDisableClientState(GL_VERTEX_ARRAY);
@@ -963,7 +907,7 @@ sub Render {
             # fall back on old behavior
             glVertexPointer_c(3, GL_FLOAT, 0, $self->bed_grid_lines->ptr());
         }
-        glColor4f( @{ $GRID_COLOR } );
+        glColor4f( @GRID_COLOR );
         glNormal3d(0,0,1);
         glDrawArrays(GL_LINES, 0, $self->bed_grid_lines->elements / 3);
         glDisableClientState(GL_VERTEX_ARRAY);
@@ -1024,7 +968,7 @@ sub Render {
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         glBegin(GL_QUADS);
-        glColor4f(@{ $COLOR_CUTPLANE });
+        glColor4f( @COLOR_CUTPLANE );
         if ($self->cutting_plane_axis == X) {
             glVertex3f($bb->x_min+$plane_z, $bb->y_min-20, $bb->z_min-20);
             glVertex3f($bb->x_min+$plane_z, $bb->y_max+20, $bb->z_min-20);
@@ -1109,9 +1053,9 @@ sub draw_volumes {
             my $b = ($volume_idx & 0x00FF0000) >> 16;
             glColor4f($r/255.0, $g/255.0, $b/255.0, 1);
         } elsif ($volume->selected) {
-            glColor4f(@{ $SELECTED_COLOR }, $volume->color->[3]);
+            glColor4f( @SELECTED_COLOR , $volume->color->[3]);
         } elsif ($volume->hover) {
-            glColor4f(@{ $HOVER_COLOR }, $volume->color->[3]);
+            glColor4f( @HOVER_COLOR, $volume->color->[3]);
         } else {
             glColor4f(@{ $volume->color });
         }
@@ -1224,6 +1168,7 @@ use OpenGL qw(:glconstants :gluconstants :glufunctions);
 use List::Util qw(first min max);
 use Slic3r::Geometry qw(scale unscale epsilon);
 use Slic3r::Print::State ':steps';
+use Slic3r::GUI::ColorScheme;
 
 __PACKAGE__->mk_accessors(qw(
     colors
@@ -1235,13 +1180,15 @@ __PACKAGE__->mk_accessors(qw(
     _objects_by_volumes
 ));
 
-
-sub default_colors { $COLOR_PARTS, $COLOR_INFILL, $COLOR_SUPPORT, $COLOR_FOUR }
-
+sub default_colors { [@COLOR_PARTS], [@COLOR_INFILL], [@COLOR_SUPPORT], [@COLOR_UNKNOWN] }
 
 sub new {
     my $class = shift;
     my $self = $class->SUPER::new(@_);
+    # Get SOLARIZED if enabled
+    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
+        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    }
     $self->colors([ $self->default_colors ]);
     $self->color_by('volume');      # object | volume
     $self->color_toolpaths_by('role'); # role | extruder

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -72,10 +72,14 @@ use constant GIMBAL_LOCK_THETA_MAX => 170;
 
 sub new {
     my ($class, $parent) = @_;
-    # Get SOLARIZED if enabled
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+
+    if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
+        my $myGetSchemeName = \&{"Slic3r::GUI::ColorScheme::$Slic3r::GUI::Settings->{_}{colorscheme}"};
+        $myGetSchemeName->();
+    } else {
+        Slic3r::GUI::ColorScheme->getDefault();
     }
+    
     # We can only enable multi sample anti aliasing with wxWidgets 3.0.3 and with a hacked Wx::GLCanvas,
     # which exports some new WX_GL_XXX constants, namely WX_GL_SAMPLE_BUFFERS and WX_GL_SAMPLES.
     my $can_multisample =
@@ -847,10 +851,17 @@ sub Render {
         glLoadIdentity();
         
         glBegin(GL_QUADS);
-        glColor3f( @BOTTOM_COLOR ); #bottom color
+        
+        my @t_color = @TOP_COLOR;
+        my @b_color = @BOTTOM_COLOR;
+        if ( $Slic3r::GUI::Settings->{_}{colorscheme} ne 'getDefault' ) {
+            @t_color = @BACKGROUND_COLOR;
+            @b_color = @BACKGROUND_COLOR;
+        }
+        glColor3f( @t_color ); # top color
         glVertex2f(-1.0,-1.0);
         glVertex2f(1,-1.0);
-        glColor3f( @TOP_COLOR ); #top color
+        glColor3f( @b_color ); # bottom color
         glVertex2f(1, 1);
         glVertex2f(-1.0, 1);
         glEnd();
@@ -894,7 +905,7 @@ sub Render {
         glEnable(GL_DEPTH_TEST);
     
         # draw grid
-        glLineWidth(3);
+        glLineWidth(2);
         glEnableClientState(GL_VERTEX_ARRAY);
         my $grid_vertex;
         if (HAS_VBO) {
@@ -1186,10 +1197,14 @@ sub new {
     my $class = shift;
     
     my $self = $class->SUPER::new(@_);
-    # Get SOLARIZED if enabled
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    
+    if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
+        my $myGetSchemeName = \&{"Slic3r::GUI::ColorScheme::$Slic3r::GUI::Settings->{_}{colorscheme}"};
+        $myGetSchemeName->();
+    } else {
+        Slic3r::GUI::ColorScheme->getDefault();
     }
+    
     $self->colors([ $self->default_colors ]);
     $self->color_by('volume');      # object | volume
     $self->color_toolpaths_by('role'); # role | extruder

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -852,16 +852,10 @@ sub Render {
         
         glBegin(GL_QUADS);
         
-        my @t_color = @TOP_COLOR;
-        my @b_color = @BOTTOM_COLOR;
-        if ( $Slic3r::GUI::Settings->{_}{colorscheme} ne 'getDefault' ) {
-            @t_color = @BACKGROUND_COLOR;
-            @b_color = @BACKGROUND_COLOR;
-        }
-        glColor3f( @t_color ); # top color
+        glColor3f( @TOP_COLOR ); # top color
         glVertex2f(-1.0,-1.0);
         glVertex2f(1,-1.0);
-        glColor3f( @b_color ); # bottom color
+        glColor3f( @BOTTOM_COLOR ); # bottom color
         glVertex2f(1, 1);
         glVertex2f(-1.0, 1);
         glEnd();

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -6,7 +6,7 @@ use POSIX;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN);
+our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_DARK @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN);
 
 # DEFAULT values
 our @SELECTED_COLOR   = (0, 1, 0);
@@ -39,6 +39,7 @@ our @SPLINE_L_PEN     = (50, 50, 50);
 our @SPLINE_O_PEN     = (200, 200, 200);
 our @SPLINE_I_PEN     = (255, 0, 0);
 our @SPLINE_R_PEN     = (5, 120, 160);
+our @BED_DARK         = (0, 0, 0);
 
 # S O L A R I Z E
 # # http://ethanschoonover.com/solarized
@@ -66,7 +67,7 @@ sub getSolarized {
     # @TOP_COLOR        = @COLOR_BASE3;       # ! Only used in getDefault
     # @BOTTOM_COLOR     = @COLOR_BASE3;       # ! Only used in getDefault
     @BACKGROUND_COLOR = @COLOR_BASE3;         # SOLID Background color - REQUIRED for NOT getDefault
-    @GRID_COLOR       = (@COLOR_BASE02, 0.4); # Grid color
+    @GRID_COLOR       = (@COLOR_BASE1, 0.4); # Grid color
     @GROUND_COLOR     = (@COLOR_BASE2,  0.4); # Ground or Plate color
     @COLOR_CUTPLANE   = (@COLOR_BASE1,  0.5);
     @COLOR_PARTS      = (@COLOR_BLUE,   1);   # Perimeter color
@@ -74,13 +75,14 @@ sub getSolarized {
     @COLOR_SUPPORT    = (@COLOR_ORANGE, 1);
     @COLOR_UNKNOWN    = (@COLOR_CYAN,   1);
     @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;    # do math -> multiply all values with 255 and round up
-    @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE02;
+    @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE1;
     @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;
     @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;
     @BED_DRAGGED      = map { ceil($_ * 255) } @COLOR_CYAN;
     @BED_CENTER       = map { ceil($_ * 255) } @COLOR_BASE1;
     @BED_SKIRT        = map { ceil($_ * 255) } @COLOR_BASE01;
     @BED_CLEARANCE    = map { ceil($_ * 255) } @COLOR_BLUE;
+    @BED_DARK         = map { ceil($_ * 255) } @COLOR_BASE01;
     @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR;
     @TOOL_DARK        = @COLOR_BASE01;
     @TOOL_SUPPORT     = @COLOR_ORANGE;
@@ -98,4 +100,6 @@ sub getDefault{
     @SELECTED_COLOR   = (0, 1, 0); # not really used... just a dummy.
 }
 
-1;
+
+
+1; # REQUIRED at EOF

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -1,0 +1,56 @@
+package Slic3r::GUI::ColorScheme;
+use strict;
+use warnings;
+
+use vars qw(@ISA @EXPORT);
+use Exporter 'import';
+our @ISA = 'Exporter';
+our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN);
+
+# DEFAULT values
+our @SELECTED_COLOR  = (0, 1, 0);
+our @HOVER_COLOR     = (0.4, 0.9, 0);           # Hover over Model
+our @TOP_COLOR       = (10/255,98/255,144/255); # Backgroud color
+our @BOTTOM_COLOR    = (0,0,0);                 # Backgroud color
+our @GRID_COLOR      = (0.2, 0.2, 0.2, 0.4);    # Grid color
+our @GROUND_COLOR    = (0.8, 0.6, 0.5, 0.4);    # Ground or Plate color
+our @COLOR_CUTPLANE  = (.8, .8, .8, 0.5);
+our @COLOR_PARTS     = (1, 0.95, 0.2, 1);       # Perimeter color
+our @COLOR_INFILL    = (1, 0.45, 0.45, 1);
+our @COLOR_SUPPORT   = (0.5, 1, 0.5, 1);
+our @COLOR_UNKNOWN   = (0.5, 0.5, 1, 1);
+
+# S O L A R I Z E
+# # http://ethanschoonover.com/solarized
+our @COLOR_BASE03    = (0.00000,0.16863,0.21176);
+our @COLOR_BASE02    = (0.02745,0.21176,0.25882);
+our @COLOR_BASE01    = (0.34510,0.43137,0.45882);
+our @COLOR_BASE00    = (0.39608,0.48235,0.51373);
+our @COLOR_BASE0     = (0.51373,0.58039,0.58824);
+our @COLOR_BASE1     = (0.57647,0.63137,0.63137);
+our @COLOR_BASE2     = (0.93333,0.90980,0.83529);
+our @COLOR_BASE3     = (0.99216,0.96471,0.89020);
+our @COLOR_YELLOW    = (0.70980,0.53725,0.00000);
+our @COLOR_ORANGE    = (0.79608,0.29412,0.08627);
+our @COLOR_RED       = (0.86275,0.19608,0.18431);
+our @COLOR_MAGENTA   = (0.82745,0.21176,0.50980);
+our @COLOR_VIOLET    = (0.42353,0.44314,0.76863);
+our @COLOR_BLUE      = (0.14902,0.54510,0.82353);
+our @COLOR_CYAN      = (0.16471,0.63137,0.59608);
+our @COLOR_GREEN     = (0.52157,0.60000,0.00000);
+
+sub getSOLARIZEDColorScheme {
+    @SELECTED_COLOR = @COLOR_MAGENTA;
+    @HOVER_COLOR    = @COLOR_VIOLET;        # Hover over Model
+    @TOP_COLOR      = @COLOR_BASE3;         # Backgroud color
+    @BOTTOM_COLOR   = @COLOR_BASE3;         # Backgroud color
+    @GRID_COLOR     = (@COLOR_BASE02, 0.4); # Grid color
+    @GROUND_COLOR   = (@COLOR_BASE2,  0.4);  # Ground or Plate color
+    @COLOR_CUTPLANE = (@COLOR_BASE1,  0.5);
+    @COLOR_PARTS    = (@COLOR_BLUE,   1);     # Perimeter color
+    @COLOR_INFILL   = (@COLOR_BASE2,  1);
+    @COLOR_SUPPORT  = (@COLOR_ORANGE, 1);
+    @COLOR_UNKNOWN  = (@COLOR_CYAN,   1);
+}
+
+1;

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -6,13 +6,15 @@ use POSIX;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_DARK @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN);
+our @EXPORT = qw($DEFAULT_COLORSCHEME $SOLID_BACKGROUNDCOLOR @SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_DARK @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN );
 
 # DEFAULT values
+our $DEFAULT_COLORSCHEME   = 1;
+our $SOLID_BACKGROUNDCOLOR = 0;
 our @SELECTED_COLOR   = (0, 1, 0);
 our @HOVER_COLOR      = (0.4, 0.9, 0);           # Hover over Model
-our @TOP_COLOR        = (0,0,0);                 # TOP Backgroud color
-our @BOTTOM_COLOR     = (10/255,98/255,144/255); # BOTTOM Backgroud color
+our @TOP_COLOR        = (10/255,98/255,144/255); # TOP Backgroud color
+our @BOTTOM_COLOR     = (0,0,0);                 # BOTTOM Backgroud color
 our @BACKGROUND_COLOR = @TOP_COLOR;              # SOLID background color
 our @GRID_COLOR       = (0.2, 0.2, 0.2, 0.4);    # Grid color
 our @GROUND_COLOR     = (0.8, 0.6, 0.5, 0.4);    # Ground or Plate color
@@ -34,7 +36,7 @@ our @TOOL_DARK        = (0, 0, 0);
 our @TOOL_SUPPORT     = (0, 0, 0);
 our @TOOL_INFILL      = (0, 0, 0);
 our @TOOL_SHADE       = (0.95, 0.95, 0.95);
-our @TOOL_COLOR       = (0.9, 0.9, 0.9);
+our @TOOL_COLOR       = (0.7, 0, 0);
 our @SPLINE_L_PEN     = (50, 50, 50);
 our @SPLINE_O_PEN     = (200, 200, 200);
 our @SPLINE_I_PEN     = (255, 0, 0);
@@ -61,48 +63,57 @@ our @COLOR_CYAN      = (0.16471,0.63137,0.59608);
 our @COLOR_GREEN     = (0.52157,0.60000,0.00000);
 
 # create your own theme:
-# 1. add new sub and name it accordingly
+# 1. add new sub and name it according to your scheme
 # 2. add that name to Preferences.pm
 # 3. Choose your newly created theme in Slic3rs' Preferences (File -> Preferences).
 
 sub getSolarized { # add this name to Preferences.pm
-# print "S O L A R I Z E D  loaded ...\n";
-    @SELECTED_COLOR   = @COLOR_MAGENTA;
-    @HOVER_COLOR      = @COLOR_VIOLET;        # Hover over Model
-    @TOP_COLOR        = @COLOR_BASE3;         # FADE Background color
-    @BOTTOM_COLOR     = @COLOR_BASE3;         # FADE Background color
-    @BACKGROUND_COLOR = @COLOR_BASE3;         # SOLID Background color - REQUIRED for NOT getDefault
-    @GRID_COLOR       = (@COLOR_BASE1, 0.4); # Grid color
-    @GROUND_COLOR     = (@COLOR_BASE2,  0.4); # Ground or Plate color
-    @COLOR_CUTPLANE   = (@COLOR_BASE1,  0.5);
-    @COLOR_PARTS      = (@COLOR_BLUE,   1);   # Perimeter color
-    @COLOR_INFILL     = (@COLOR_BASE2,  1);
-    @COLOR_SUPPORT    = (@COLOR_ORANGE, 1);
-    @COLOR_UNKNOWN    = (@COLOR_CYAN,   1);
-    @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;    # do math -> multiply each value by 255 and round up
-    @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE1;
-    @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;
-    @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;
-    @BED_DRAGGED      = map { ceil($_ * 255) } @COLOR_CYAN;
-    @BED_CENTER       = map { ceil($_ * 255) } @COLOR_BASE1;
-    @BED_SKIRT        = map { ceil($_ * 255) } @COLOR_BASE01;
-    @BED_CLEARANCE    = map { ceil($_ * 255) } @COLOR_BLUE;
-    @BED_DARK         = map { ceil($_ * 255) } @COLOR_BASE01;
-    @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR;
-    @TOOL_DARK        = @COLOR_BASE01;
-    @TOOL_SUPPORT     = @COLOR_ORANGE;
-    @TOOL_INFILL      = @COLOR_BASE01;
-    @TOOL_COLOR       = @COLOR_BLUE;
-    @TOOL_SHADE       = @COLOR_BASE2;
-    @SPLINE_L_PEN     = map { ceil($_ * 255) } @COLOR_BASE01;
-    @SPLINE_O_PEN     = map { ceil($_ * 255) } @COLOR_BASE1;
-    @SPLINE_I_PEN     = map { ceil($_ * 255) } @COLOR_MAGENTA;
-    @SPLINE_R_PEN     = map { ceil($_ * 255) } @COLOR_VIOLET;
+    $DEFAULT_COLORSCHEME   = 0;               # DISABLE default color scheme
+    $SOLID_BACKGROUNDCOLOR = 1;               # Switch between SOLID or FADED background color
+    @SELECTED_COLOR   = @COLOR_MAGENTA;       # Color of selected Model
+    @HOVER_COLOR      = @COLOR_VIOLET;        # Color when hovering over Model
+    # @TOP_COLOR        = @COLOR_BASE2;         # FADE Background color - only used if $SOLID_BACKGROUNDCOLOR = 0
+    # @BOTTOM_COLOR     = @COLOR_BASE02;        # FADE Background color - only used if $SOLID_BACKGROUNDCOLOR = 0
+    @BACKGROUND_COLOR = @COLOR_BASE3;         # SOLID Background color  - REQUIRED for NOT getDefault
+    @GRID_COLOR       = (@COLOR_BASE1, 0.4);  # Grid
+    @GROUND_COLOR     = (@COLOR_BASE2, 0.4);  # Ground or Plate
+    @COLOR_CUTPLANE   = (@COLOR_BASE1, 0.5);  # Cut plane
+    @COLOR_PARTS      = (@TOOL_COLOR,  1);    # Perimeter
+    @COLOR_INFILL     = (@COLOR_BASE2, 1);    # Infill
+    @COLOR_SUPPORT    = (@TOOL_SUPPORT, 1);   # Support
+    @COLOR_UNKNOWN    = (@COLOR_CYAN,  1);    # I don't know what that color's for!
+    
+    # 2DBed.pm and ./plater/2D.pm colors
+    @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;      # do math -> multiply each value by 255 and round up
+    @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE1;      # Bed, Ground or Plate
+    @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;   # Selected Model
+    @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;      # Models on bed
+    @BED_DRAGGED      = map { ceil($_ * 255) } @COLOR_CYAN;       # Color while dragging
+    @BED_CENTER       = map { ceil($_ * 255) } @COLOR_BASE1;      # Cross hair
+    @BED_SKIRT        = map { ceil($_ * 255) } @COLOR_BASE01;     # Brim/Skirt
+    @BED_CLEARANCE    = map { ceil($_ * 255) } @COLOR_BLUE;       # not sure what that does
+    @BED_DARK         = map { ceil($_ * 255) } @COLOR_BASE01;     # not sure what that does
+    @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR; # Backgroud color, this time RGB
+    
+    # 2DToolpaths.pm colors : LAYERS Tab
+    @TOOL_DARK        = @COLOR_BASE01;  # Brim/Skirt
+    @TOOL_SUPPORT     = @COLOR_GREEN;   # Support
+    @TOOL_INFILL      = @COLOR_BASE1;   # Infill
+    @TOOL_COLOR       = @COLOR_BLUE;    # Perimeter
+    @TOOL_SHADE       = @COLOR_BASE2;   # Shade; model inside
+    
+    # Colors for *Layer heights...* dialog
+    @SPLINE_L_PEN     = map { ceil($_ * 255) } @COLOR_BASE01;  # Line color
+    @SPLINE_O_PEN     = map { ceil($_ * 255) } @COLOR_BASE1;   # Original color
+    @SPLINE_I_PEN     = map { ceil($_ * 255) } @COLOR_MAGENTA; # Interactive color
+    @SPLINE_R_PEN     = map { ceil($_ * 255) } @COLOR_VIOLET;  # Resulting color
 
 }
 
 sub getDefault{
-    @SELECTED_COLOR   = (0, 1, 0); # not really used... just a dummy.
+    $DEFAULT_COLORSCHEME   = 1;               # ENABLE default color scheme
+    # Define your function here
+    # getDefault is just a dummy function and uses the default values from above.
 }
 
 

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -2,10 +2,11 @@ package Slic3r::GUI::ColorScheme;
 use strict;
 use warnings;
 
+use POSIX;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS);
+our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_BACKGROUND @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE);
 
 # DEFAULT values
 our @SELECTED_COLOR  = (0, 1, 0);
@@ -23,6 +24,16 @@ our @BED_COLOR       = (255, 255, 255);
 our @BED_GRID        = (230, 230, 230);
 our @BED_SELECTED    = (255, 166, 128);
 our @BED_OBJECTS     = (210, 210, 210);
+our @BED_DRAGGED     = (128, 128, 255);
+our @BED_CENTER      = (200, 200, 200);
+our @BED_SKIRT       = (150, 150, 150);
+our @BED_CLEARANCE   = (0, 0, 200);
+our @BED_BACKGROUND  = (255, 255, 255);
+our @TOOL_DARK       = (0, 0, 0);
+our @TOOL_SUPPORT    = (0, 0, 0);
+our @TOOL_INFILL     = (0, 0, 0);
+our @TOOL_SHADE      = (0.95, 0.95, 0.95);
+
 
 # S O L A R I Z E
 # # http://ethanschoonover.com/solarized
@@ -55,10 +66,19 @@ sub getSOLARIZEDColorScheme {
     @COLOR_INFILL   = (@COLOR_BASE2,  1);
     @COLOR_SUPPORT  = (@COLOR_ORANGE, 1);
     @COLOR_UNKNOWN  = (@COLOR_CYAN,   1);
-    @BED_COLOR      = map { $_ * 255 } @COLOR_BASE2;
-    @BED_GRID       = map { $_ * 255 } @COLOR_BASE02;
-    @BED_SELECTED   = map { $_ * 255 } @SELECTED_COLOR;
-    @BED_OBJECTS    = map { $_ * 255 } @COLOR_PARTS;
+    @BED_COLOR      = map { ceil($_ * 255) } @COLOR_BASE2;
+    @BED_GRID       = map { ceil($_ * 255) } @COLOR_BASE02;
+    @BED_SELECTED   = map { ceil($_ * 255) } @SELECTED_COLOR;
+    @BED_OBJECTS    = map { ceil($_ * 255) } @COLOR_PARTS;
+    @BED_DRAGGED    = map { ceil($_ * 255) } @COLOR_CYAN;
+    @BED_CENTER     = map { ceil($_ * 255) } @COLOR_BASE1;
+    @BED_SKIRT      = map { ceil($_ * 255) } @COLOR_BASE01;
+    @BED_CLEARANCE  = map { ceil($_ * 255) } @COLOR_BLUE;
+    @BED_BACKGROUND = map { ceil($_ * 255) } @COLOR_BASE3;
+    @TOOL_DARK      = @COLOR_BASE01;
+    @TOOL_SUPPORT   = @COLOR_ORANGE;
+    @TOOL_INFILL    = @COLOR_BASE01;
+
 }
 
 1;

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -60,7 +60,12 @@ our @COLOR_BLUE      = (0.14902,0.54510,0.82353);
 our @COLOR_CYAN      = (0.16471,0.63137,0.59608);
 our @COLOR_GREEN     = (0.52157,0.60000,0.00000);
 
-sub getSolarized {
+# create your own theme:
+# 1. add new sub and name it accordingly
+# 2. add that name to Preferences.pm
+# 3. Choose your newly created theme in Slic3rs' Preferences (File -> Preferences).
+
+sub getSolarized { # add this name to Preferences.pm
 # print "S O L A R I Z E D  loaded ...\n";
     @SELECTED_COLOR   = @COLOR_MAGENTA;
     @HOVER_COLOR      = @COLOR_VIOLET;        # Hover over Model
@@ -74,7 +79,7 @@ sub getSolarized {
     @COLOR_INFILL     = (@COLOR_BASE2,  1);
     @COLOR_SUPPORT    = (@COLOR_ORANGE, 1);
     @COLOR_UNKNOWN    = (@COLOR_CYAN,   1);
-    @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;    # do math -> multiply all values with 255 and round up
+    @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;    # do math -> multiply each value by 255 and round up
     @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE1;
     @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;
     @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -64,8 +64,8 @@ sub getSolarized {
 # print "S O L A R I Z E D  loaded ...\n";
     @SELECTED_COLOR   = @COLOR_MAGENTA;
     @HOVER_COLOR      = @COLOR_VIOLET;        # Hover over Model
-    # @TOP_COLOR        = @COLOR_BASE3;       # ! Only used in getDefault
-    # @BOTTOM_COLOR     = @COLOR_BASE3;       # ! Only used in getDefault
+    @TOP_COLOR        = @COLOR_BASE3;         # FADE Background color
+    @BOTTOM_COLOR     = @COLOR_BASE3;         # FADE Background color
     @BACKGROUND_COLOR = @COLOR_BASE3;         # SOLID Background color - REQUIRED for NOT getDefault
     @GRID_COLOR       = (@COLOR_BASE1, 0.4); # Grid color
     @GROUND_COLOR     = (@COLOR_BASE2,  0.4); # Ground or Plate color

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -6,34 +6,39 @@ use POSIX;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_BACKGROUND @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE);
+our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN);
 
 # DEFAULT values
-our @SELECTED_COLOR  = (0, 1, 0);
-our @HOVER_COLOR     = (0.4, 0.9, 0);           # Hover over Model
-our @TOP_COLOR       = (10/255,98/255,144/255); # Backgroud color
-our @BOTTOM_COLOR    = (0,0,0);                 # Backgroud color
-our @GRID_COLOR      = (0.2, 0.2, 0.2, 0.4);    # Grid color
-our @GROUND_COLOR    = (0.8, 0.6, 0.5, 0.4);    # Ground or Plate color
-our @COLOR_CUTPLANE  = (.8, .8, .8, 0.5);
-our @COLOR_PARTS     = (1, 0.95, 0.2, 1);       # Perimeter color
-our @COLOR_INFILL    = (1, 0.45, 0.45, 1);
-our @COLOR_SUPPORT   = (0.5, 1, 0.5, 1);
-our @COLOR_UNKNOWN   = (0.5, 0.5, 1, 1);
-our @BED_COLOR       = (255, 255, 255);
-our @BED_GRID        = (230, 230, 230);
-our @BED_SELECTED    = (255, 166, 128);
-our @BED_OBJECTS     = (210, 210, 210);
-our @BED_DRAGGED     = (128, 128, 255);
-our @BED_CENTER      = (200, 200, 200);
-our @BED_SKIRT       = (150, 150, 150);
-our @BED_CLEARANCE   = (0, 0, 200);
-our @BED_BACKGROUND  = (255, 255, 255);
-our @TOOL_DARK       = (0, 0, 0);
-our @TOOL_SUPPORT    = (0, 0, 0);
-our @TOOL_INFILL     = (0, 0, 0);
-our @TOOL_SHADE      = (0.95, 0.95, 0.95);
-
+our @SELECTED_COLOR   = (0, 1, 0);
+our @HOVER_COLOR      = (0.4, 0.9, 0);           # Hover over Model
+our @TOP_COLOR        = (0,0,0);                 # TOP Backgroud color
+our @BOTTOM_COLOR     = (10/255,98/255,144/255); # BOTTOM Backgroud color
+our @BACKGROUND_COLOR = @TOP_COLOR;              # SOLID background color
+our @GRID_COLOR       = (0.2, 0.2, 0.2, 0.4);    # Grid color
+our @GROUND_COLOR     = (0.8, 0.6, 0.5, 0.4);    # Ground or Plate color
+our @COLOR_CUTPLANE   = (.8, .8, .8, 0.5);
+our @COLOR_PARTS      = (1, 0.95, 0.2, 1);       # Perimeter color
+our @COLOR_INFILL     = (1, 0.45, 0.45, 1);
+our @COLOR_SUPPORT    = (0.5, 1, 0.5, 1);
+our @COLOR_UNKNOWN    = (0.5, 0.5, 1, 1);
+our @BED_COLOR        = (255, 255, 255);
+our @BED_GRID         = (230, 230, 230);
+our @BED_SELECTED     = (255, 166, 128);
+our @BED_OBJECTS      = (210, 210, 210);
+our @BED_DRAGGED      = (128, 128, 255);
+our @BED_CENTER       = (200, 200, 200);
+our @BED_SKIRT        = (150, 150, 150);
+our @BED_CLEARANCE    = (0, 0, 200);
+our @BACKGROUND255    = (255, 255, 255);
+our @TOOL_DARK        = (0, 0, 0);
+our @TOOL_SUPPORT     = (0, 0, 0);
+our @TOOL_INFILL      = (0, 0, 0);
+our @TOOL_SHADE       = (0.95, 0.95, 0.95);
+our @TOOL_COLOR       = (0.9, 0.9, 0.9);
+our @SPLINE_L_PEN     = (50, 50, 50);
+our @SPLINE_O_PEN     = (200, 200, 200);
+our @SPLINE_I_PEN     = (255, 0, 0);
+our @SPLINE_R_PEN     = (5, 120, 160);
 
 # S O L A R I Z E
 # # http://ethanschoonover.com/solarized
@@ -54,31 +59,43 @@ our @COLOR_BLUE      = (0.14902,0.54510,0.82353);
 our @COLOR_CYAN      = (0.16471,0.63137,0.59608);
 our @COLOR_GREEN     = (0.52157,0.60000,0.00000);
 
-sub getSOLARIZEDColorScheme {
-    @SELECTED_COLOR = @COLOR_MAGENTA;
-    @HOVER_COLOR    = @COLOR_VIOLET;        # Hover over Model
-    @TOP_COLOR      = @COLOR_BASE3;         # Backgroud color
-    @BOTTOM_COLOR   = @COLOR_BASE3;         # Backgroud color
-    @GRID_COLOR     = (@COLOR_BASE02, 0.4); # Grid color
-    @GROUND_COLOR   = (@COLOR_BASE2,  0.4);  # Ground or Plate color
-    @COLOR_CUTPLANE = (@COLOR_BASE1,  0.5);
-    @COLOR_PARTS    = (@COLOR_BLUE,   1);     # Perimeter color
-    @COLOR_INFILL   = (@COLOR_BASE2,  1);
-    @COLOR_SUPPORT  = (@COLOR_ORANGE, 1);
-    @COLOR_UNKNOWN  = (@COLOR_CYAN,   1);
-    @BED_COLOR      = map { ceil($_ * 255) } @COLOR_BASE2;
-    @BED_GRID       = map { ceil($_ * 255) } @COLOR_BASE02;
-    @BED_SELECTED   = map { ceil($_ * 255) } @SELECTED_COLOR;
-    @BED_OBJECTS    = map { ceil($_ * 255) } @COLOR_PARTS;
-    @BED_DRAGGED    = map { ceil($_ * 255) } @COLOR_CYAN;
-    @BED_CENTER     = map { ceil($_ * 255) } @COLOR_BASE1;
-    @BED_SKIRT      = map { ceil($_ * 255) } @COLOR_BASE01;
-    @BED_CLEARANCE  = map { ceil($_ * 255) } @COLOR_BLUE;
-    @BED_BACKGROUND = map { ceil($_ * 255) } @COLOR_BASE3;
-    @TOOL_DARK      = @COLOR_BASE01;
-    @TOOL_SUPPORT   = @COLOR_ORANGE;
-    @TOOL_INFILL    = @COLOR_BASE01;
+sub getSolarized {
+# print "S O L A R I Z E D  loaded ...\n";
+    @SELECTED_COLOR   = @COLOR_MAGENTA;
+    @HOVER_COLOR      = @COLOR_VIOLET;        # Hover over Model
+    # @TOP_COLOR        = @COLOR_BASE3;       # ! Only used in getDefault
+    # @BOTTOM_COLOR     = @COLOR_BASE3;       # ! Only used in getDefault
+    @BACKGROUND_COLOR = @COLOR_BASE3;         # SOLID Background color - REQUIRED for NOT getDefault
+    @GRID_COLOR       = (@COLOR_BASE02, 0.4); # Grid color
+    @GROUND_COLOR     = (@COLOR_BASE2,  0.4); # Ground or Plate color
+    @COLOR_CUTPLANE   = (@COLOR_BASE1,  0.5);
+    @COLOR_PARTS      = (@COLOR_BLUE,   1);   # Perimeter color
+    @COLOR_INFILL     = (@COLOR_BASE2,  1);
+    @COLOR_SUPPORT    = (@COLOR_ORANGE, 1);
+    @COLOR_UNKNOWN    = (@COLOR_CYAN,   1);
+    @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;    # do math -> multiply all values with 255 and round up
+    @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE02;
+    @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;
+    @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;
+    @BED_DRAGGED      = map { ceil($_ * 255) } @COLOR_CYAN;
+    @BED_CENTER       = map { ceil($_ * 255) } @COLOR_BASE1;
+    @BED_SKIRT        = map { ceil($_ * 255) } @COLOR_BASE01;
+    @BED_CLEARANCE    = map { ceil($_ * 255) } @COLOR_BLUE;
+    @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR;
+    @TOOL_DARK        = @COLOR_BASE01;
+    @TOOL_SUPPORT     = @COLOR_ORANGE;
+    @TOOL_INFILL      = @COLOR_BASE01;
+    @TOOL_COLOR       = @COLOR_BLUE;
+    @TOOL_SHADE       = @COLOR_BASE2;
+    @SPLINE_L_PEN     = map { ceil($_ * 255) } @COLOR_BASE01;
+    @SPLINE_O_PEN     = map { ceil($_ * 255) } @COLOR_BASE1;
+    @SPLINE_I_PEN     = map { ceil($_ * 255) } @COLOR_MAGENTA;
+    @SPLINE_R_PEN     = map { ceil($_ * 255) } @COLOR_VIOLET;
 
+}
+
+sub getDefault{
+    @SELECTED_COLOR   = (0, 1, 0); # not really used... just a dummy.
 }
 
 1;

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -5,7 +5,7 @@ use warnings;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN);
+our @EXPORT = qw(@SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS);
 
 # DEFAULT values
 our @SELECTED_COLOR  = (0, 1, 0);
@@ -19,6 +19,10 @@ our @COLOR_PARTS     = (1, 0.95, 0.2, 1);       # Perimeter color
 our @COLOR_INFILL    = (1, 0.45, 0.45, 1);
 our @COLOR_SUPPORT   = (0.5, 1, 0.5, 1);
 our @COLOR_UNKNOWN   = (0.5, 0.5, 1, 1);
+our @BED_COLOR       = (255, 255, 255);
+our @BED_GRID        = (230, 230, 230);
+our @BED_SELECTED    = (255, 166, 128);
+our @BED_OBJECTS     = (210, 210, 210);
 
 # S O L A R I Z E
 # # http://ethanschoonover.com/solarized
@@ -51,6 +55,10 @@ sub getSOLARIZEDColorScheme {
     @COLOR_INFILL   = (@COLOR_BASE2,  1);
     @COLOR_SUPPORT  = (@COLOR_ORANGE, 1);
     @COLOR_UNKNOWN  = (@COLOR_CYAN,   1);
+    @BED_COLOR      = map { $_ * 255 } @COLOR_BASE2;
+    @BED_GRID       = map { $_ * 255 } @COLOR_BASE02;
+    @BED_SELECTED   = map { $_ * 255 } @SELECTED_COLOR;
+    @BED_OBJECTS    = map { $_ * 255 } @COLOR_PARTS;
 }
 
 1;

--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -30,7 +30,7 @@ sub new {
     
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, $size, wxTAB_TRAVERSAL);
     # This has only effect on MacOS. On Windows and Linux/GTK, the background is painted by $self->repaint().
-    $self->SetBackgroundColour(Wx::wxWHITE);
+    $self->SetBackgroundColour(Wx::Colour->new(@BED_BACKGROUND));
 
     $self->{objects}            = $objects;
     $self->{model}              = $model;
@@ -43,12 +43,12 @@ sub new {
     $self->{objects_brush}      = Wx::Brush->new(Wx::Colour->new(@BED_OBJECTS), wxSOLID);
     $self->{instance_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
     $self->{selected_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
-    $self->{dragged_brush}      = Wx::Brush->new(Wx::Colour->new(128,128,255), wxSOLID);
+    $self->{dragged_brush}      = Wx::Brush->new(Wx::Colour->new(@BED_DRAGGED), wxSOLID);
     $self->{transparent_brush}  = Wx::Brush->new(Wx::Colour->new(0,0,0), wxTRANSPARENT);
     $self->{grid_pen}           = Wx::Pen->new(Wx::Colour->new(@BED_GRID), 1, wxSOLID);
-    $self->{print_center_pen}   = Wx::Pen->new(Wx::Colour->new(200,200,200), 1, wxSOLID);
-    $self->{clearance_pen}      = Wx::Pen->new(Wx::Colour->new(0,0,200), 1, wxSOLID);
-    $self->{skirt_pen}          = Wx::Pen->new(Wx::Colour->new(150,150,150), 1, wxSOLID);
+    $self->{print_center_pen}   = Wx::Pen->new(Wx::Colour->new(@BED_CENTER), 1, wxSOLID);
+    $self->{clearance_pen}      = Wx::Pen->new(Wx::Colour->new(@BED_CLEARANCE), 1, wxSOLID);
+    $self->{skirt_pen}          = Wx::Pen->new(Wx::Colour->new(@BED_SKIRT), 1, wxSOLID);
 
     $self->{user_drawn_background} = $^O ne 'darwin';
 
@@ -116,8 +116,9 @@ sub repaint {
         # On MacOS the background is erased, on Windows the background is not erased 
         # and on Linux/GTK the background is erased to gray color.
         # Fill DC with the background on Windows & Linux/GTK.
-        my $brush_background = Wx::Brush->new(Wx::wxWHITE, wxSOLID);
-        $dc->SetPen(wxWHITE_PEN);
+        my $brush_background = Wx::Brush->new(Wx::Colour->new(@BED_BACKGROUND), wxSOLID);# Wx::Brush->new(Wx::wxWHITE, wxSOLID);
+        my $pen_background   = Wx::Pen->new(Wx::Colour->new(@BED_BACKGROUND), 1, wxSOLID);
+        $dc->SetPen($pen_background);
         $dc->SetBrush($brush_background);
         my $rect = $self->GetUpdateRegion()->GetBox();
         $dc->DrawRectangle($rect->GetLeft(), $rect->GetTop(), $rect->GetWidth(), $rect->GetHeight());

--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -47,11 +47,13 @@ sub new {
     $self->{instance_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
     $self->{selected_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
     $self->{dragged_brush}      = Wx::Brush->new(Wx::Colour->new(@BED_DRAGGED), wxSOLID);
+    $self->{bed_brush}          = Wx::Brush->new(Wx::Colour->new(@BED_COLOR), wxSOLID);
     $self->{transparent_brush}  = Wx::Brush->new(Wx::Colour->new(0,0,0), wxTRANSPARENT);
     $self->{grid_pen}           = Wx::Pen->new(Wx::Colour->new(@BED_GRID), 1, wxSOLID);
     $self->{print_center_pen}   = Wx::Pen->new(Wx::Colour->new(@BED_CENTER), 1, wxSOLID);
     $self->{clearance_pen}      = Wx::Pen->new(Wx::Colour->new(@BED_CLEARANCE), 1, wxSOLID);
     $self->{skirt_pen}          = Wx::Pen->new(Wx::Colour->new(@BED_SKIRT), 1, wxSOLID);
+    $self->{dark_pen}           = Wx::Pen->new(Wx::Colour->new(@BED_DARK), 1, wxSOLID);
 
     $self->{user_drawn_background} = $^O ne 'darwin';
 
@@ -126,15 +128,11 @@ sub repaint {
         my $rect = $self->GetUpdateRegion()->GetBox();
         $dc->DrawRectangle($rect->GetLeft(), $rect->GetTop(), $rect->GetWidth(), $rect->GetHeight());
     }
-
-    # draw grid
-    $dc->SetPen($self->{grid_pen});
-    $dc->DrawLine(map @$_, @$_) for @{$self->{grid}};
     
     # draw bed
     {
         $dc->SetPen($self->{print_center_pen});
-        $dc->SetBrush($self->{transparent_brush});
+        $dc->SetBrush($self->{bed_brush});
         $dc->DrawPolygon($self->scaled_points_to_pixel($self->{bed_polygon}, 1), 0, 0);
     }
     
@@ -152,7 +150,7 @@ sub repaint {
     
     # draw frame
     if (0) {
-        $dc->SetPen(wxBLACK_PEN);
+        $dc->SetPen($self->{dark_pen});
         $dc->SetBrush($self->{transparent_brush});
         $dc->DrawRectangle(0, 0, @size);
     }
@@ -162,10 +160,14 @@ sub repaint {
         $dc->SetTextForeground(Wx::Colour->new(@BED_OBJECTS));
         $dc->SetFont(Wx::Font->new(14, wxDEFAULT, wxNORMAL, wxNORMAL));
         $dc->DrawLabel(CANVAS_TEXT, Wx::Rect->new(0, 0, $self->GetSize->GetWidth, $self->GetSize->GetHeight), wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
+    } else {
+        # draw grid
+        $dc->SetPen($self->{grid_pen});
+        $dc->DrawLine(map @$_, @$_) for @{$self->{grid}};
     }
     
     # draw thumbnails
-    $dc->SetPen(wxBLACK_PEN);
+    $dc->SetPen($self->{dark_pen});
     $self->clean_instance_thumbnails;
     for my $obj_idx (0 .. $#{$self->{objects}}) {
         my $object = $self->{objects}[$obj_idx];

--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -24,13 +24,16 @@ sub new {
     my $class = shift;
     my ($parent, $size, $objects, $model, $config) = @_;
     
-    if ($Slic3r::GUI::Settings->{_}{colorschema_solarized}) {
-        Slic3r::GUI::ColorScheme::getSOLARIZEDColorScheme();
+    if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
+        my $myGetSchemeName = \&{"Slic3r::GUI::ColorScheme::$Slic3r::GUI::Settings->{_}{colorscheme}"};
+        $myGetSchemeName->();
+    } else {
+        Slic3r::GUI::ColorScheme->getDefault();
     }
     
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, $size, wxTAB_TRAVERSAL);
     # This has only effect on MacOS. On Windows and Linux/GTK, the background is painted by $self->repaint().
-    $self->SetBackgroundColour(Wx::Colour->new(@BED_BACKGROUND));
+    $self->SetBackgroundColour(Wx::Colour->new(@BACKGROUND255));
 
     $self->{objects}            = $objects;
     $self->{model}              = $model;
@@ -116,8 +119,8 @@ sub repaint {
         # On MacOS the background is erased, on Windows the background is not erased 
         # and on Linux/GTK the background is erased to gray color.
         # Fill DC with the background on Windows & Linux/GTK.
-        my $brush_background = Wx::Brush->new(Wx::Colour->new(@BED_BACKGROUND), wxSOLID);# Wx::Brush->new(Wx::wxWHITE, wxSOLID);
-        my $pen_background   = Wx::Pen->new(Wx::Colour->new(@BED_BACKGROUND), 1, wxSOLID);
+        my $brush_background = Wx::Brush->new(Wx::Colour->new(@BACKGROUND255), wxSOLID);
+        my $pen_background   = Wx::Pen->new(Wx::Colour->new(@BACKGROUND255), 1, wxSOLID);
         $dc->SetPen($pen_background);
         $dc->SetBrush($brush_background);
         my $rect = $self->GetUpdateRegion()->GetBox();

--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -70,13 +70,13 @@ sub new {
             my ($s, $event) = @_;
 
             my $key = $event->GetKeyCode;
-            if ($key == 65 || $key == 314) {       # 64=a ; 314 = ?
+            if ($key == 65 || $key == 314) {
                 $self->nudge_instance('left');
-            } elsif ($key == 87 || $key == 315) {  # 87=w ; 315 = ?
+            } elsif ($key == 87 || $key == 315) {
                 $self->nudge_instance('up');
-            } elsif ($key == 68 || $key == 316) {  # 68=d ; 316 = ?
+            } elsif ($key == 68 || $key == 316) {
                 $self->nudge_instance('right');
-            } elsif ($key == 83 || $key == 317) {  # 83=s ; 317 = ?
+            } elsif ($key == 83 || $key == 317) {
                 $self->nudge_instance('down');
             } else {
                 $event->Skip;

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -8,7 +8,7 @@ use warnings;
 use utf8;
 
 use Slic3r::Print::State ':steps';
-use Wx qw(:misc :sizer :slider :statictext);
+use Wx qw(:misc :sizer :slider :statictext wxWHITE);
 use Wx::Event qw(EVT_SLIDER EVT_KEY_DOWN);
 use base qw(Wx::Panel Class::Accessor);
 
@@ -21,15 +21,15 @@ sub new {
     my $class = shift;
     my ($parent, $print) = @_;
 
+    my $self = $class->SUPER::new($parent, -1, wxDefaultPosition);
     if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( my $getScheme =  Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
         $getScheme->();
+        $self->SetBackgroundColour(Wx::Colour->new(@BACKGROUND255));
     } else {
         Slic3r::GUI::ColorScheme->getDefault();
+        $self->SetBackgroundColour(Wx::wxWHITE);
     }
-    
-    my $self = $class->SUPER::new($parent, -1, wxDefaultPosition);
-    $self->SetBackgroundColour(Wx::Colour->new(@BACKGROUND255));
-    
+
     # init GUI elements
     my $canvas = $self->{canvas} = Slic3r::GUI::Plater::2DToolpaths::Canvas->new($self, $print);
     my $slider = $self->{slider} = Wx::Slider->new(
@@ -328,7 +328,12 @@ sub Render {
     $self->SetCurrent($context);
     $self->InitGL;
     
-    glClearColor(1, 1, 1, 0);
+    if ($DEFAULT_COLORSCHEME==1){
+		glClearColor(1, 1, 1, 0);
+	} else{
+		glClearColor(@BACKGROUND_COLOR, 0);
+	}
+    
     glClear(GL_COLOR_BUFFER_BIT);
     
     if (!$self->GetParent->enabled || !$self->layers) {
@@ -424,7 +429,7 @@ sub Render {
         
         foreach my $layerm (@{$layer->regions}) {
             if ($object->step_done(STEP_PERIMETERS)) {
-                $self->color(@COLOR_PARTS);
+                $self->color(@TOOL_COLOR);
                 $self->_draw($object, $print_z, $_) for map @$_, @{$layerm->perimeters};
             }
             

--- a/lib/Slic3r/GUI/Plater/3DPreview.pm
+++ b/lib/Slic3r/GUI/Plater/3DPreview.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 use Slic3r::Print::State ':steps';
-use Wx qw(:misc :sizer :slider :statictext wxWHITE);
+use Wx qw(:misc :sizer :slider :statictext);
 use Wx::Event qw(EVT_SLIDER EVT_KEY_DOWN);
 use base qw(Wx::Panel Class::Accessor);
 

--- a/lib/Slic3r/GUI/Plater/SplineControl.pm
+++ b/lib/Slic3r/GUI/Plater/SplineControl.pm
@@ -9,9 +9,19 @@ use Wx qw(:misc :pen :brush :sizer :font :cursor wxTAB_TRAVERSAL);
 use Wx::Event qw(EVT_MOUSE_EVENTS EVT_PAINT EVT_ERASE_BACKGROUND EVT_SIZE);
 use base 'Wx::Panel';
 
+# Color Scheme
+use Slic3r::GUI::ColorScheme;
+
 sub new {
     my $class = shift;
     my ($parent, $size, $object) = @_;
+    
+    if ( ( defined $Slic3r::GUI::Settings->{_}{colorscheme} ) && ( Slic3r::GUI::ColorScheme->can($Slic3r::GUI::Settings->{_}{colorscheme}) ) ) {
+        my $myGetSchemeName = \&{"Slic3r::GUI::ColorScheme::$Slic3r::GUI::Settings->{_}{colorscheme}"};
+        $myGetSchemeName->();
+    } else {
+        Slic3r::GUI::ColorScheme->getDefault();
+    }
     
     my $self = $class->SUPER::new($parent, -1, wxDefaultPosition, $size, wxTAB_TRAVERSAL);
     
@@ -19,12 +29,12 @@ sub new {
     $self->{is_valid} = 0;
     
     # This has only effect on MacOS. On Windows and Linux/GTK, the background is painted by $self->repaint().
-    $self->SetBackgroundColour(Wx::wxWHITE);
+    $self->SetBackgroundColour(Wx::Colour->new(@BACKGROUND255));
 
-    $self->{line_pen}           = Wx::Pen->new(Wx::Colour->new(50,50,50), 1, wxSOLID);
-    $self->{original_pen}       = Wx::Pen->new(Wx::Colour->new(200,200,200), 1, wxSOLID);
-    $self->{interactive_pen}    = Wx::Pen->new(Wx::Colour->new(255,0,0), 1, wxSOLID);
-    $self->{resulting_pen}      = Wx::Pen->new(Wx::Colour->new(5,120,160), 1, wxSOLID);
+    $self->{line_pen}           = Wx::Pen->new(Wx::Colour->new(@SPLINE_L_PEN), 1, wxSOLID);
+    $self->{original_pen}       = Wx::Pen->new(Wx::Colour->new(@SPLINE_O_PEN), 1, wxSOLID);
+    $self->{interactive_pen}    = Wx::Pen->new(Wx::Colour->new(@SPLINE_I_PEN), 1, wxSOLID);
+    $self->{resulting_pen}      = Wx::Pen->new(Wx::Colour->new(@SPLINE_R_PEN), 1, wxSOLID);
 
     $self->{user_drawn_background} = $^O ne 'darwin';
 
@@ -63,8 +73,9 @@ sub repaint {
         # On MacOS the background is erased, on Windows the background is not erased 
         # and on Linux/GTK the background is erased to gray color.
         # Fill DC with the background on Windows & Linux/GTK.
-        my $brush_background = Wx::Brush->new(Wx::wxWHITE, wxSOLID);
-        $dc->SetPen(wxWHITE_PEN);
+        my $brush_background = Wx::Brush->new(Wx::Colour->new(@BACKGROUND255), wxSOLID);
+        my $pen_background   = Wx::Pen->new(Wx::Colour->new(@BACKGROUND255), 1, wxSOLID);
+        $dc->SetPen($pen_background);
         $dc->SetBrush($brush_background);
         my $rect = $self->GetUpdateRegion()->GetBox();
         $dc->DrawRectangle($rect->GetLeft(), $rect->GetTop(), $rect->GetWidth(), $rect->GetHeight());

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -20,7 +20,7 @@ sub new {
         },
         label_width => 200,
     );
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # version_check
         opt_id      => 'version_check',
         type        => 'bool',
         label       => 'Check for updates',
@@ -28,35 +28,35 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{version_check} // 1,
         readonly    => !wxTheApp->have_version_check,
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # remember_output_path
         opt_id      => 'remember_output_path',
         type        => 'bool',
         label       => 'Remember output directory',
         tooltip     => 'If this is enabled, Slic3r will prompt the last output directory instead of the one containing the input files.',
         default     => $Slic3r::GUI::Settings->{_}{remember_output_path},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # autocenter
         opt_id      => 'autocenter',
         type        => 'bool',
         label       => 'Auto-center parts (x,y)',
         tooltip     => 'If this is enabled, Slic3r will auto-center objects around the print bed center.',
         default     => $Slic3r::GUI::Settings->{_}{autocenter},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # autoalignz
         opt_id      => 'autoalignz',
         type        => 'bool',
         label       => 'Auto-align parts (z=0)',
         tooltip     => 'If this is enabled, Slic3r will auto-align objects z value to be on the print bed at z=0.',
         default     => $Slic3r::GUI::Settings->{_}{autoalignz},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # invert_zoom
         opt_id      => 'invert_zoom',
         type        => 'bool',
         label       => 'Invert zoom in previews',
         tooltip     => 'If this is enabled, Slic3r will invert the direction of mouse-wheel zoom in preview panes.',
         default     => $Slic3r::GUI::Settings->{_}{invert_zoom},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # background_processing
         opt_id      => 'background_processing',
         type        => 'bool',
         label       => 'Background processing',
@@ -64,35 +64,35 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{background_processing},
         readonly    => !$Slic3r::have_threads,
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # threads
         opt_id      => 'threads',
         type        => 'i',
         label       => 'Threads',
         tooltip     => $Slic3r::Config::Options->{threads}{tooltip},
         default     => $Slic3r::GUI::Settings->{_}{threads},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # tabbed_preset_editors
         opt_id      => 'tabbed_preset_editors',
         type        => 'bool',
         label       => 'Display profile editors as tabs',
         tooltip     => 'When opening a profile editor, it will be shown in a dialog or in a tab according to this option.',
         default     => $Slic3r::GUI::Settings->{_}{tabbed_preset_editors},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # show_host
         opt_id      => 'show_host',
         type        => 'bool',
         label       => 'Show Controller Tab (requires restart)',
         tooltip     => 'Shows/Hides the Controller Tab. Requires a restart of Slic3r.',
         default     => $Slic3r::GUI::Settings->{_}{show_host},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # nudge_val
         opt_id      => 'nudge_val',
         type        => 's',
         label       => '2D plater nudge value',
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # colorscheme
         opt_id      => 'colorscheme', # this needs to match the name chosen in $Settings
         type        => 'select', # option type, use a different type if desired
         label       => 'Color Scheme', # Label text

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -18,7 +18,7 @@ sub new {
             my ($opt_id) = @_;
             $self->{values}{$opt_id} = $optgroup->get_value($opt_id);
         },
-        label_width => 250,
+        label_width => 200,
     );
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'version_check',
@@ -92,29 +92,19 @@ sub new {
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
-
-    
-    my $optgroupstyle;
-    $optgroupstyle = Slic3r::GUI::OptionsGroup->new(
-        parent  => $self,
-        title   => 'Scheme',
-        on_change => sub {
-            my ($opt_id) = @_;
-            $self->{values}{$opt_id} = $optgroupstyle->get_value($opt_id);
-        },
-        label_width => 250,
-    );
-    $optgroupstyle->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
-        opt_id      => 'colorschema_solarized',
-        type        => 'bool',
-        label       => 'Solarized Color Scheme',
-        tooltip     => 'Restart of Slic3r after changes required. \n Precision colors for machines and people (http://ethanschoonover.com/solarized).',
-        default     => $Slic3r::GUI::Settings->{_}{colorschema_solarized}  // 0,
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+        opt_id      => 'colorscheme', # this needs to match the name chosen in $Settings
+        type        => 'select', # option type, use a different type if desired
+        label       => 'Color Scheme', # Label text
+        tooltip     => 'Choose between color schemes - restart of Slic3r required.', # tooltop text
+        labels      => ['Default','Solarized'], # this is for a select box, it's an array of values
+        values      => ['getDefault','getSolarized'], # these are the values that a selectbox can take.
+        default     => $Slic3r::GUI::Settings->{_}{colorscheme} // 'getDefault', # this is a reference to what you put in GUI.pm
+        width       => 130
     ));
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);
     $sizer->Add($optgroup->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);
-    $sizer->Add($optgroupstyle->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);
     
     my $buttons = $self->CreateStdDialogButtonSizer(wxOK | wxCANCEL);
     EVT_BUTTON($self, wxID_OK, sub { $self->_accept });

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -92,6 +92,13 @@ sub new {
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+        opt_id      => 'colorschema_solarized',
+        type        => 'bool',
+        label       => 'Solarized Color Scheme',
+        tooltip     => 'Precision colors for machines and people (http://ethanschoonover.com/solarized).',
+        default     => $Slic3r::GUI::Settings->{_}{colorschema_solarized}  // 0,
+    ));
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);
     $sizer->Add($optgroup->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -100,7 +100,7 @@ sub new {
         labels      => ['Default','Solarized'], # add more schemes, if you want in ColorScheme.pm.
         values      => ['getDefault','getSolarized'], # add more schemes, if you want - those are the names of the corresponding function in ColorScheme.pm.
         default     => $Slic3r::GUI::Settings->{_}{colorscheme} // 'getDefault',
-        width       => 130
+        width       => 130,
     ));
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -93,13 +93,13 @@ sub new {
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # colorscheme
-        opt_id      => 'colorscheme', # this needs to match the name chosen in $Settings
-        type        => 'select', # option type, use a different type if desired
-        label       => 'Color Scheme', # Label text
-        tooltip     => 'Choose between color schemes - restart of Slic3r required.', # tooltop text
-        labels      => ['Default','Solarized'], # this is for a select box, it's an array of values
-        values      => ['getDefault','getSolarized'], # these are the values that a selectbox can take.
-        default     => $Slic3r::GUI::Settings->{_}{colorscheme} // 'getDefault', # this is a reference to what you put in GUI.pm
+        opt_id      => 'colorscheme',
+        type        => 'select',
+        label       => 'Color Scheme',
+        tooltip     => 'Choose between color schemes - restart of Slic3r required.',
+        labels      => ['Default','Solarized'], # add more schemes, if you want in ColorScheme.pm.
+        values      => ['getDefault','getSolarized'], # add more schemes, if you want - those are the names of the corresponding function in ColorScheme.pm.
+        default     => $Slic3r::GUI::Settings->{_}{colorscheme} // 'getDefault',
         width       => 130
     ));
     

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -18,7 +18,7 @@ sub new {
             my ($opt_id) = @_;
             $self->{values}{$opt_id} = $optgroup->get_value($opt_id);
         },
-        label_width => 200,
+        label_width => 250,
     );
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'version_check',
@@ -92,7 +92,19 @@ sub new {
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
+
+    
+    my $optgroupstyle;
+    $optgroupstyle = Slic3r::GUI::OptionsGroup->new(
+        parent  => $self,
+        title   => 'Scheme',
+        on_change => sub {
+            my ($opt_id) = @_;
+            $self->{values}{$opt_id} = $optgroupstyle->get_value($opt_id);
+        },
+        label_width => 250,
+    );
+    $optgroupstyle->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(
         opt_id      => 'colorschema_solarized',
         type        => 'bool',
         label       => 'Solarized Color Scheme',
@@ -102,6 +114,7 @@ sub new {
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);
     $sizer->Add($optgroup->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);
+    $sizer->Add($optgroupstyle->sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 10);
     
     my $buttons = $self->CreateStdDialogButtonSizer(wxOK | wxCANCEL);
     EVT_BUTTON($self, wxID_OK, sub { $self->_accept });

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -96,7 +96,7 @@ sub new {
         opt_id      => 'colorschema_solarized',
         type        => 'bool',
         label       => 'Solarized Color Scheme',
-        tooltip     => 'Precision colors for machines and people (http://ethanschoonover.com/solarized).',
+        tooltip     => 'Restart of Slic3r after changes required. \n Precision colors for machines and people (http://ethanschoonover.com/solarized).',
         default     => $Slic3r::GUI::Settings->{_}{colorschema_solarized}  // 0,
     ));
     


### PR DESCRIPTION
Added an optional color scheme ([solarized](http://ethanschoonover.com/solarized)) to Slic3r.
See option in `Files` -> `Preferences` -> `Color Scheme`.

![image](https://user-images.githubusercontent.com/10420187/36677071-9049ac58-1b0d-11e8-9df7-baeb0f81084a.png)

![image](https://user-images.githubusercontent.com/10420187/36677080-959a126a-1b0d-11e8-9693-34dbb175a133.png)

![image](https://user-images.githubusercontent.com/10420187/36677252-fae66d44-1b0d-11e8-8dcb-4ff4919922ba.png)

![image](https://user-images.githubusercontent.com/10420187/36677276-07314a60-1b0e-11e8-9cf1-2c449f4a9668.png)


