### PR TITLE
Attempt to bridge support layer pillars

### DIFF
--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -681,8 +681,8 @@ GCode::needs_retraction(const Polyline &travel, ExtrusionRole role)
     
     if (role == erSupportMaterial) {
         const SupportLayer* support_layer = dynamic_cast<const SupportLayer*>(this->layer);
-        if (support_layer != NULL && support_layer->support_islands.contains(travel)) {
-            // skip retraction if this is a travel move inside a support material island
+        if (support_layer != NULL) {
+            // skip retraction if this is a travel move for a support layer
             return false;
         }
     }


### PR DESCRIPTION
This PR is intended to help address issues with the "pillars" support method producing very thin pillars that sometimes fall over during print (for example #3485 and #2017).

It simply disables retraction inside of all support layer moves, which helps the pillars adhere to each other without using much extra material.

It would be better to implement a more full fix like requiring a minimum area for support pillars (see #2949) or explicitly bridging the pillars, but that is beyond my current skill with this complicated codebase :)

If the approach taken in this PR is generally acceptable, there is still more that should be done:

- Preserve retraction behavior on the base layer of the support material
- Preserve retraction behavior when moving into or out of a support layer (maybe check if the starting and ending points of `travel` are within the support islands)
- Don't change behavior for other types of support material
- Tests

I would appreciate tips on how to achieve any of those things.