### PR TITLE
Wrong colors in 2d platter and instance color missing

### DIFF
--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -6,7 +6,7 @@ use POSIX;
 use vars qw(@ISA @EXPORT);
 use Exporter 'import';
 our @ISA = 'Exporter';
-our @EXPORT = qw($DEFAULT_COLORSCHEME $SOLID_BACKGROUNDCOLOR @SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_DARK @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN );
+our @EXPORT = qw($DEFAULT_COLORSCHEME $SOLID_BACKGROUNDCOLOR @SELECTED_COLOR @HOVER_COLOR @TOP_COLOR @BOTTOM_COLOR @GRID_COLOR @GROUND_COLOR @COLOR_CUTPLANE @COLOR_PARTS @COLOR_INFILL @COLOR_SUPPORT @COLOR_UNKNOWN @BED_COLOR @BED_GRID @BED_SELECTED @BED_OBJECTS @BED_INSTANCE @BED_DRAGGED @BED_CENTER @BED_SKIRT @BED_CLEARANCE @BED_DARK @BACKGROUND255 @TOOL_DARK @TOOL_SUPPORT @TOOL_STEPPERIM @TOOL_INFILL @TOOL_SHADE @TOOL_COLOR @BACKGROUND_COLOR @SPLINE_L_PEN @SPLINE_O_PEN @SPLINE_I_PEN @SPLINE_R_PEN );
 
 # DEFAULT values
 our $DEFAULT_COLORSCHEME   = 1;
@@ -27,6 +27,7 @@ our @BED_COLOR        = (255, 255, 255);
 our @BED_GRID         = (230, 230, 230);
 our @BED_SELECTED     = (255, 166, 128);
 our @BED_OBJECTS      = (210, 210, 210);
+our @BED_INSTANCE     = (255, 128, 128);
 our @BED_DRAGGED      = (128, 128, 255);
 our @BED_CENTER       = (200, 200, 200);
 our @BED_SKIRT        = (150, 150, 150);
@@ -34,9 +35,10 @@ our @BED_CLEARANCE    = (0, 0, 200);
 our @BACKGROUND255    = (255, 255, 255);
 our @TOOL_DARK        = (0, 0, 0);
 our @TOOL_SUPPORT     = (0, 0, 0);
-our @TOOL_INFILL      = (0, 0, 0);
+our @TOOL_INFILL      = (0, 0, 0.7);
+our @TOOL_STEPPERIM   = (0.7, 0, 0);
 our @TOOL_SHADE       = (0.95, 0.95, 0.95);
-our @TOOL_COLOR       = (0.7, 0, 0);
+our @TOOL_COLOR       = (0.9, 0.9, 0.9);
 our @SPLINE_L_PEN     = (50, 50, 50);
 our @SPLINE_O_PEN     = (200, 200, 200);
 our @SPLINE_I_PEN     = (255, 0, 0);
@@ -86,7 +88,8 @@ sub getSolarized { # add this name to Preferences.pm
     # 2DBed.pm and ./plater/2D.pm colors
     @BED_COLOR        = map { ceil($_ * 255) } @COLOR_BASE2;      # do math -> multiply each value by 255 and round up
     @BED_GRID         = map { ceil($_ * 255) } @COLOR_BASE1;      # Bed, Ground or Plate
-    @BED_SELECTED     = map { ceil($_ * 255) } @SELECTED_COLOR;   # Selected Model
+    @BED_SELECTED     = map { ceil($_ * 255) } @COLOR_YELLOW;     # Selected Model
+    @BED_INSTANCE     = map { ceil($_ * 255) } @SELECTED_COLOR;   # Real selected Model
     @BED_OBJECTS      = map { ceil($_ * 255) } @COLOR_PARTS;      # Models on bed
     @BED_DRAGGED      = map { ceil($_ * 255) } @COLOR_CYAN;       # Color while dragging
     @BED_CENTER       = map { ceil($_ * 255) } @COLOR_BASE1;      # Cross hair
@@ -99,7 +102,8 @@ sub getSolarized { # add this name to Preferences.pm
     @TOOL_DARK        = @COLOR_BASE01;  # Brim/Skirt
     @TOOL_SUPPORT     = @COLOR_GREEN;   # Support
     @TOOL_INFILL      = @COLOR_BASE1;   # Infill
-    @TOOL_COLOR       = @COLOR_BLUE;    # Perimeter
+    @TOOL_COLOR       = @COLOR_BLUE;    # Real Perimeter
+    @TOOL_STEPPERIM   = @COLOR_CYAN;    # Inner Perimeter
     @TOOL_SHADE       = @COLOR_BASE2;   # Shade; model inside
     
     # Colors for *Layer heights...* dialog

--- a/lib/Slic3r/GUI/Plater/2D.pm
+++ b/lib/Slic3r/GUI/Plater/2D.pm
@@ -44,7 +44,7 @@ sub new {
     $self->{on_instances_moved} = sub {};
     
     $self->{objects_brush}      = Wx::Brush->new(Wx::Colour->new(@BED_OBJECTS), wxSOLID);
-    $self->{instance_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
+    $self->{instance_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_INSTANCE), wxSOLID);
     $self->{selected_brush}     = Wx::Brush->new(Wx::Colour->new(@BED_SELECTED), wxSOLID);
     $self->{dragged_brush}      = Wx::Brush->new(Wx::Colour->new(@BED_DRAGGED), wxSOLID);
     $self->{bed_brush}          = Wx::Brush->new(Wx::Colour->new(@BED_COLOR), wxSOLID);

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -429,7 +429,7 @@ sub Render {
         
         foreach my $layerm (@{$layer->regions}) {
             if ($object->step_done(STEP_PERIMETERS)) {
-                $self->color(@TOOL_COLOR);
+                $self->color(@TOOL_STEPPERIM);
                 $self->_draw($object, $print_z, $_) for map @$_, @{$layerm->perimeters};
             }
             


### PR DESCRIPTION
Wrong default colors for:
* 2d platter step perimeter and infill
* selection if instances where present

See here:
https://github.com/alexrj/Slic3r/issues/4352
Thanks for reporting.