### PR TITLE
Corrected volumetric checkbox informaiton

### DIFF
--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1726,7 +1726,7 @@ PrintConfigDef::PrintConfigDef()
 
     def = this->add("use_volumetric_e", coBool);
     def->label = __TRANS("Use volumetric E");
-    def->tooltip = __TRANS("This experimental setting uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.");
+    def->tooltip = __TRANS("This setting, exprimental in Marlin but stable in Smoothie, uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.");
     def->cli = "use-volumetric-e!";
     def->default_value = new ConfigOptionBool(false);
 


### PR DESCRIPTION
Corrected volumetric checkbox information by clearly stating that volumetric is only experimental in Marlin but stable in Smoothie.